### PR TITLE
Check for Function type with instanceof rather than the call property to fix incompatibility with ClojureScript

### DIFF
--- a/src/Model.coffee
+++ b/src/Model.coffee
@@ -99,7 +99,7 @@ eventListener = (method, pattern, callback, at) ->
   if at
     if typeof pattern is 'string'
       pattern = at + '.' + pattern
-    else if pattern.call
+    else if pattern instanceof Function
       callback = pattern
       pattern = at
     else
@@ -107,9 +107,7 @@ eventListener = (method, pattern, callback, at) ->
 
   else
     # on(type, listener)
-    # Test for function by looking for call, since pattern can be a regex,
-    # which has a typeof == 'function' as well
-    return pattern if pattern.call
+    return pattern if pattern instanceof Function
 
   # on(method, pattern, callback)
   re = eventRegExp pattern


### PR DESCRIPTION
**Update:** I resubmitted this pull request because I messed up the commits on the previous one.

While I was trying out Racer with ClojureScript, I was getting an error with the following code:

```
(.on model "set" "*"
  (fn [id value]
    (js/alert value)))
```

The error was

```
 Uncaught Error: addListener only takes instances of Function
```

I figured out the problem was that ClojureScript's core library defines String.prototype.call, so when eventListener() checks the existence of the call method, it thinks a String is actually a Function and returns prematurely. I modified the code to avoid this problem by using instanceof to check the type instead.
