### PR TITLE
New version of mocha no longer supports coffee-script by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ macro:
 
 ROOT := $(shell pwd)
 MOCHA_TESTS := $(shell find test/ -name '*.mocha.coffee')
-MOCHA := ./node_modules/mocha/bin/mocha
+MOCHA := ./node_modules/mocha/bin/mocha --compilers coffee:coffee-script
 OUT_FILE = "test-output.tmp"
 
 g = "."


### PR DESCRIPTION
I needed to change this to get the tests to run.
