### PR TITLE
Set coffee-script dep to 1.3.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "devDependencies": {
     "mocha": ">=0.9.0",
     "expect.js": ">=0.1.2",
-    "coffee-script": "3.x",
+    "coffee-script": "1.3.x",
     "console.color": ">=0.0.4",
     "racer-journal-redis": "*",
     "racer-pubsub-redis": "*",


### PR DESCRIPTION
coffee-script's latest version is still 1.3.1, not 3.x.

http://search.npmjs.org/#/coffee-script
