### PR TITLE
Allow configuring socket.io 'polling duration'

### DIFF
--- a/src/Store.js
+++ b/src/Store.js
@@ -86,6 +86,9 @@ Store.prototype.listen = function (to, namespace) {
   io.configure( function () {
     io.set('browser.client', false);
     io.set('transports', racer.get('transports'));
+    if (racer.get('polling duration')) {
+      io.set('polling duration', racer.get('polling duration'));
+    }
   });
   io.configure('production', function () {
     io.set('log level', 1);


### PR DESCRIPTION
Heroku requires setting io 'polling duration' to 10 when using xhr-polling [(see here)](https://devcenter.heroku.com/articles/using-socket-io-with-node-js-on-heroku/), this commit adds config option
