### PR TITLE
Fix missing session bug in access control guards

### DIFF
--- a/src/descriptor/descriptor.Store.js
+++ b/src/descriptor/descriptor.Store.js
@@ -193,6 +193,7 @@ module.exports = {
       , shouldSubscribe: shouldSubscribe
       , subs: subs
       , ver: ver
+      , session: socket.session
         // TODO Pass in proper context
       , context: this.context(this.scopedContext)
       };


### PR DESCRIPTION
Racer doesn't add a `session` property to the `req` object when the client is requesting a snapshot update. This causes problems (see #37) when during a snapshot request an access control guard tries to decide whether the client is allowed to do something based on the session.

I found that adding the line in the pull request fixes the issue for me.
