### PR TITLE
Pin uglify-js version to 1.3.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "socket.io-client": ">=0.9.6",
     "es5-shim": ">=1.2.10",
     "browserify": ">=1.13.3",
-    "uglify-js": ">=1.3.1",
+    "uglify-js": "1.3.x",
     "share": "0.4.1",
     "node-uuid": "1.3.3",
     "hooks": "0.2.1",


### PR DESCRIPTION
Seems like the recent change of uglify-js2 to uglify-js causes some issues in spinning up a new derby project.  Here's a quick fix to pin it to 1.3.x.

See: https://github.com/codeparty/derby/issues/171
