### PR TITLE
Resolved 500 internal server error when using model.subscribe without callback

### DIFF
--- a/lib/descriptor/util.js
+++ b/lib/descriptor/util.js
@@ -1,3 +1,5 @@
+noop = require('../util').noop;
+
 module.exports = {
   normArgs: normArgs
 };


### PR DESCRIPTION
When using model.subscribe without callback, the default "noop" function was not defined.
