### PR TITLE
Modify deepCopy() to correctly clone dates

### DIFF
--- a/lib/util/index.js
+++ b/lib/util/index.js
@@ -158,6 +158,7 @@ function objEquiv (a, b, ignoreMap) {
 // TODO Test this
 function deepCopy (obj) {
   if (obj === null) return null;
+  if (obj instanceof Date) return new Date(obj);
   if (typeof obj === 'object') {
     var copy;
     if (Array.isArray(obj)) {


### PR DESCRIPTION
This allows dates to be passed as query motif arguments
