### PR TITLE
Allow chaining with multi-field where

### DIFF
--- a/lib/descriptor/query/QueryBuilder.js
+++ b/lib/descriptor/query/QueryBuilder.js
@@ -91,6 +91,7 @@ QueryBuilder.prototype.where = function (param) {
       this.equals(arg);
     }
   }
+  return this;
 };
 
 QueryBuilder.prototype.toJSON = function () {


### PR DESCRIPTION
This allows `.where({ ... }).sort(...)` in query motifs
