### PR TITLE
Allow queries on model refs

### DIFF
--- a/lib/computed/filter.js
+++ b/lib/computed/filter.js
@@ -1,4 +1,5 @@
-var lookup = require('../path').lookup
+var pathLookup = require('../path').lookup
+  , treeLookup = require('../tree').lookup
   , transaction = require('../transaction')
   , util = require('../util')
   , indexOf = util.indexOf
@@ -14,6 +15,19 @@ module.exports = {
 , filterDomain: filterDomain
 , deriveFilterFn: deriveFilterFn
 };
+
+function lookup(fieldName, doc, model) {
+  // If we have a model, use treeLookup() to support queries on refs
+  if (!model)
+    return pathLookup(fieldName, doc);
+
+  // Since we have no way of knowing where to find doc
+  // in the model, I add it as a fake property.
+  var maskedWorld = Object.create(model.get());
+  maskedWorld.__$$$$querydoc$$$$ = doc;
+  return treeLookup({ world: maskedWorld, splits: {} }, '__$$$$querydoc$$$$.' + fieldName).node;
+}
+
 
 /**
  * Creates a filter function based on a query represented as json.
@@ -68,7 +82,7 @@ var fieldPredicates = {
         val = this.model.get(val.$ref);
       }
 
-      var currVal = lookup(fieldName, doc);
+      var currVal = lookup(fieldName, doc, this.model);
       if (typeof currVal === 'object') {
         return deepEqual(currVal, val);
       }
@@ -78,7 +92,7 @@ var fieldPredicates = {
       if (val && val.$ref) {
         val = this.model.get(val.$ref);
       }
-      var currVal = lookup(fieldName, doc);
+      var currVal = lookup(fieldName, doc, this.model);
       if (typeof currVal === 'object') {
         return ! deepEqual(currVal, val);
       }
@@ -88,7 +102,7 @@ var fieldPredicates = {
       if (val && val.$ref) {
         val = this.model.get(val.$ref);
       }
-      var currVal = lookup(fieldName, doc);
+      var currVal = lookup(fieldName, doc, this.model);
       if (typeof currVal === 'object') {
         return deepEqual(currVal, val);
       }
@@ -98,7 +112,7 @@ var fieldPredicates = {
       if (val && val.$ref) {
         val = this.model.get(val.$ref);
       }
-      var currVal = lookup(fieldName, doc);
+      var currVal = lookup(fieldName, doc, this.model);
       if (typeof currVal === 'object') {
         return ! deepEqual(currVal, val);
       }
@@ -129,32 +143,32 @@ var fieldPredicates = {
       if (val && val.$ref) {
         val = this.model.get(val.$ref);
       }
-      return lookup(fieldName, doc) > val;
+      return lookup(fieldName, doc, this.model) > val;
     }
   , gte: function (fieldName, val, doc) {
       if (val && val.$ref) {
         val = this.model.get(val.$ref);
       }
-      return lookup(fieldName, doc) >= val;
+      return lookup(fieldName, doc, this.model) >= val;
     }
   , lt: function (fieldName, val, doc) {
       if (val && val.$ref) {
         val = this.model.get(val.$ref);
       }
-      return lookup(fieldName, doc) < val;
+      return lookup(fieldName, doc, this.model) < val;
     }
   , lte: function (fieldName, val, doc) {
       if (val && val.$ref) {
         val = this.model.get(val.$ref);
       }
-      return lookup(fieldName, doc) <= val;
+      return lookup(fieldName, doc, this.model) <= val;
     }
   , within: function (fieldName, list, doc) {
       if (list && list.$ref) {
         list = this.model.get(list.$ref);
       }
       if (!list.length) return false;
-      var x = lookup(fieldName, doc);
+      var x = lookup(fieldName, doc, this.model);
       if (x && x.constructor === Object) return ~deepIndexOf(list, x);
       return ~list.indexOf(x);
     }
@@ -162,7 +176,7 @@ var fieldPredicates = {
       if (list && list.$ref) {
         list = this.model.get(list.$ref);
       }
-      var docList = lookup(fieldName, doc);
+      var docList = lookup(fieldName, doc, this.model);
       if (typeof docList === 'undefined') {
         if (list.length) return false;
         return true; // contains nothing
@@ -181,7 +195,7 @@ var fieldPredicates = {
       if (shouldExist && shouldExist.$ref) {
         shouldExist = this.model.get(shouldExist.$ref);
       }
-      var val = lookup(fieldName, doc)
+      var val = lookup(fieldName, doc, this.model)
         , doesExist = (typeof val !== 'undefined');
       return doesExist === shouldExist;
     }


### PR DESCRIPTION
I modified the field lookup procedure for in-memory model queries to allow queries to compare refs inside models.
