### PR TITLE
Fix refList bugs with nested paths

### DIFF
--- a/lib/refs/refList.js
+++ b/lib/refs/refList.js
@@ -93,18 +93,6 @@ function createGetter (from, to, key) {
         }
       }
 
-      // Look ahead to see if we need to access a member of this refList and
-      // modify the property chain so it makes sense in the context of the
-      // dereferenced refList
-      var prevRest = firstNonEmptyList(meta.prevRests)
-        , nextProp = prevRest && prevRest[0]
-      if (nextProp && nextProp !== 'length') {
-        if (! Array.isArray(domain)) {
-          var id = pointerList[nextProp];
-          prevRest[0] = id;
-        } // Otherwise, prevRest[0] = originallySpecifiedIndexInArray
-      }
-
       if (meta.refEmitter) {
         meta.refEmitter.onRefList(node, pathToRef, rest, pointerList, dereffed, dereffedKey);
       }
@@ -137,12 +125,5 @@ function getDoc (domain, id, to, pathToRef) {
     })]
   } else {
     throw new TypeError();
-  }
-}
-function firstNonEmptyList (lists) {
-  if (!lists) return;
-  var i = 0, list;
-  while (list = lists[i++]) {
-    if (list.length) return list;
   }
 }


### PR DESCRIPTION
See https://groups.google.com/forum/?fromgroups=#!topic/derbyjs/oLr2xlFjGcQ

Test case:

``` js
model.set("_data", {
    21: { id: 21, name: 'a' },
    31: { id: 31, name: 'b' },
    41: { id: 41, name: 'c' }
});
model.ref("_all", model.filter('_data'));
model.ref("_subset", model.filter("_all").where('name').within(['b', 'c']));

console.log("get('_subset')[0]:", model.get('_subset')[0]);
console.log("get('_subset.0'):", model.get('_subset.0'));

model.set("_keys", [31,41]);

model.refList("_items", "_all", "_keys");

console.log("get('_items')[0]:", model.get('_items')[0]);
console.log("get('_items.0'):", model.get('_items.0'));
```

Output:

```
get('_subset')[0]: Object {id: 31, name: "b"}
get('_subset.0'): Object {id: 21, name: "a"}
get('_items')[0]: Object {id: 31, name: "b"}
get('_items.0'): undefined 
```

`prevRests` should probably be removed entirely
