### PR TITLE
Don't update queries until after model refresh

### DIFF
--- a/lib/descriptor/query/scope.js
+++ b/lib/descriptor/query/scope.js
@@ -142,6 +142,22 @@ function createMutatorListener (model, scopedModel, memoryQuery, queryId) {
     var searchSpace = model.get(ns);
     if (!searchSpace) return;
 
+    // If the entire model is updating, wait until
+    // it finishes, then rerun the entire query. I
+    // cannot optimize if only one event happened,
+    // since other events may have been suppressed
+    var updating = model.get("_$updating");
+    if (updating) {
+        // If we already flagged this query to run
+        // on reInit, do nothing.
+        if (updating[memoryQuery.id]) {
+            model.once("reInit", function () {
+                queryType.onOverwriteNs(searchSpace, memoryQuery, model);
+            });
+        }
+        return;
+    }
+
     var queryType = queryTypes[memoryQuery.type];
     var currResult = scopedModel.get();
 

--- a/lib/txns/txns.Model.js
+++ b/lib/txns/txns.Model.js
@@ -251,6 +251,10 @@ module.exports = {
         // come up if rendering in strange states
         if (typeof DERBY !== 'undefined') DERBY.app.dom._preventUpdates = true;
 
+        // Queries and potentially other things store state in this object
+        // to mark that each affected item should only update once.
+        model.set("_$updating", {});
+
         var oldTxnQueue = model._txnQueue
           , oldTxns = model._txns
           , txnQueue = model._txnQueue = []
@@ -284,6 +288,7 @@ module.exports = {
 
         if (typeof DERBY !== 'undefined') DERBY.app.dom._preventUpdates = false;
 
+        model.del("_$updating");
         model.emit('reInit');
       });
 


### PR DESCRIPTION
See https://groups.google.com/forum/?fromgroups=#!topic/derbyjs/GJ9FCqgyQGk

> Whenever the server sends snapshotUpdate:replace, Racer (on the client) clears all persistent parts of the model, then rebuilds them from the server update.
> This triggers set events for each object in every collection, which then triggers more set events on every query that is (indirectly) based on the collection (through listenerQueryMutator).
> The problem is that the original subscription query never clears its resultIds (_$queries._2.resultIds).
> Therefore, when the listenerQueryMutator for the nested query calls scopedModel.get() (in order to update the results of the in-memory query), it tries to resolve the refList for the subscribed query, which at this point refers to non-existent documents.  (because the collection is still being populated)

I have not tested this thoroughly
