### PR TITLE
Reuse existing MemoryQueries from model

### DIFF
--- a/lib/descriptor/query/TransformBuilder.js
+++ b/lib/descriptor/query/TransformBuilder.js
@@ -1,4 +1,5 @@
 var QueryBuilder = require('./QueryBuilder')
+  , queryTypes = require('./types')
   , MemoryQuery = require('./MemoryQuery')
   , setupQueryModelScope = require('./scope')
   , filterDomain = require('../../computed/filter').filterDomain
@@ -98,16 +99,22 @@ TransformBuilder.prototype.type = 'find';
 TransformBuilder.prototype._genScopedModel = function () {
   // syncRun is also called by the Query Model Scope on dependency changes
   var model = this._model
-    , domain = model.get(this.ns)
     , filterFn = this.filterFn;
 
   // TODO Register the transform, so it can be cleaned up when we no longer
   // need it
 
   var queryJson = QueryBuilder.prototype.toJSON.call(this)
+    , queryId = QueryBuilder.hash(queryJson, filterFn);
+
+  if (model[queryId])
+    return queryTypes[queryJson.type].getScopedModel(model, queryId);
+
+  var memoryQuery = this.memoryQuery = new MemoryQuery(queryJson, model)
     , comparator = this._comparator
-    , memoryQuery = this.memoryQuery = new MemoryQuery(queryJson, model)
-    ;
+    , domain = model.get(this.ns)
+    , filterFn = this.filterFn;
+
   if (filterFn) {
     var oldSyncRun = memoryQuery.syncRun
       , oldFilterTest = memoryQuery.filterTest;
@@ -124,7 +131,6 @@ TransformBuilder.prototype._genScopedModel = function () {
   }
   if (comparator) memoryQuery.sort(comparator);
   var result = memoryQuery.syncRun(domain);
-  var queryId = QueryBuilder.hash(queryJson, filterFn);
   return setupQueryModelScope(model, memoryQuery, queryId, result, this.dependencies);
 };
 

--- a/lib/descriptor/query/types/count.js
+++ b/lib/descriptor/query/types/count.js
@@ -10,6 +10,10 @@ exports.assignInitialResult = function (model, queryId, initialResult) {
   model.set(getResultPath(queryId), initialResult || 0);
 };
 
+exports.getScopedModel = function (model, queryId) {
+    return model.at(getResultPath(queryId));
+};
+
 exports.createScopedModel = function (model, memoryQuery, queryId) {
   var ns = memoryQuery.ns
   return model.at(getResultPath(queryId));

--- a/lib/descriptor/query/types/find.js
+++ b/lib/descriptor/query/types/find.js
@@ -42,6 +42,10 @@ exports.assignInitialResult = function (model, queryId, initialResult) {
   model.set(getPointerPath(queryId), ids);
 };
 
+exports.getScopedModel = function (model, queryId) {
+    return model.at(refPath(queryId));
+};
+
 exports.createScopedModel = function (model, memoryQuery, queryId, initialResult) {
   var ns = memoryQuery.ns;
   return model.refList(refPath(queryId), ns, getPointerPath(queryId));

--- a/lib/descriptor/query/types/findOne.js
+++ b/lib/descriptor/query/types/findOne.js
@@ -36,6 +36,10 @@ exports.assignInitialResult = function (model, queryId, initialResult) {
   model.set(getPointerPath(queryId), initialResult.id);
 };
 
+exports.getScopedModel = function (model, queryId) {
+    return model.at(refPath(queryId));
+};
+
 exports.createScopedModel = function (model, memoryQuery, queryId) {
   var ns = memoryQuery.ns
   return model.ref(refPath(queryId), ns, getPointerPath(queryId));


### PR DESCRIPTION
I changed `TransformBuilder._genScopedModel` to check whether this query already exists and return a scoped model for the existing query.

This fixes a bug involving missing queryIds for duplicate queries, and makes them faster too.
