### PR TITLE
Changed examples to use dev racer

### DIFF
--- a/examples/letters/client.coffee
+++ b/examples/letters/client.coffee
@@ -1,4 +1,4 @@
-racer = require 'racer'
+racer = require '../../lib/racer'
 
 process.nextTick ->
   racer.init @init

--- a/examples/letters/package.json
+++ b/examples/letters/package.json
@@ -4,7 +4,6 @@
   "version": "0.0.12",
   "main": "./server.js",
   "dependencies": {
-    "racer": "*",
     "express": ">=2.4",
     "connect-gzip": ">=0.1"
   },

--- a/examples/letters/server.coffee
+++ b/examples/letters/server.coffee
@@ -1,7 +1,7 @@
 express = require 'express'
 gzip = require 'connect-gzip'
 fs = require 'fs'
-racer = require 'racer'
+racer = require '../../lib/racer'
 http = require 'http'
 
 app = express()

--- a/examples/pad/client.coffee
+++ b/examples/pad/client.coffee
@@ -1,5 +1,5 @@
-racer = require 'racer'
-racer.use require 'racer/lib/ot'
+racer = require '../../lib/racer'
+racer.use require '../..//lib/ot'
 
 process.nextTick ->
   racer.init @init

--- a/examples/pad/package.json
+++ b/examples/pad/package.json
@@ -4,7 +4,6 @@
   "version": "0.0.12",
   "main": "./server.js",
   "dependencies": {
-    "racer": "*",
     "express": ">=2.4",
     "connect-gzip": ">=0.1"
   },

--- a/examples/pad/server.coffee
+++ b/examples/pad/server.coffee
@@ -1,8 +1,8 @@
 express = require 'express'
 gzip = require 'connect-gzip'
 fs = require 'fs'
-racer = require 'racer'
-racer.use require 'racer/lib/ot'
+racer = require '../../lib/racer'
+racer.use require '../../lib/ot'
 http = require 'http'
 
 app = express()

--- a/examples/todos/client.coffee
+++ b/examples/todos/client.coffee
@@ -1,4 +1,4 @@
-racer = require 'racer'
+racer = require '../../lib/racer'
 todoHtml = require('./shared').todoHtml
 
 process.nextTick ->

--- a/examples/todos/package.json
+++ b/examples/todos/package.json
@@ -4,7 +4,6 @@
   "version": "0.0.12",
   "main": "./server.js",
   "dependencies": {
-    "racer": "*",
     "express": ">=2.4",
     "connect-gzip": ">=0.1"
   },

--- a/examples/todos/server.coffee
+++ b/examples/todos/server.coffee
@@ -1,7 +1,7 @@
 express = require 'express'
 gzip = require 'connect-gzip'
 fs = require 'fs'
-racer = require 'racer'
+racer = require '../../lib/racer'
 shared = require './shared'
 http = require 'http'
 


### PR DESCRIPTION
So you can change racer and see it in the examples and so it won't rely on the published version (currently out of date)
