### PR TITLE
Update count queries when data changes

### DIFF
--- a/lib/descriptor/query/types/count.js
+++ b/lib/descriptor/query/types/count.js
@@ -1,4 +1,5 @@
 var PRIVATE_COLLECTION = require('./constants').PRIVATE_COLLECTION
+var isSpeculative = require('../../../util/speculative').isSpeculative;
 exports.exec = function (matches, memoryQuery) {
   if (Array.isArray(matches)) {
     return matches.length
@@ -20,9 +21,7 @@ function getResultPath (queryId) {
 }
 
 exports.onOverwriteNs = function (docs, countQuery, model) {
-  return; // TODO Figure out how best to handle count later
-
-  var queryId = findOneQuery.id
+  var queryId = countQuery.id
     , count = countQuery.syncRun(docs);
   model.set(getResultPath(queryId), count);
 };
@@ -32,36 +31,56 @@ exports.onRemoveNs = function (docs, countQuery, model) {
 };
 
 exports.onAddDoc = function (newDoc, oldDoc, countQuery, model, searchSpace, currResult) {
-  return; // TODO Figure out how best to handle count later
-
   var ns = countQuery.ns
     , doesBelong = countQuery.filterTest(newDoc, ns);
   if (! doesBelong) return;
+
   var resultPath = getResultPath(countQuery.id);
   model.set(resultPath, (currResult || 0) + 1);
 };
 
 exports.onInsertDocs = function (newDocs, countQuery, model, searchSpace, currResult) {
-  return; // TODO Figure out how best to handle count later
+  var belongCount = 0;
 
-  model.set(pointerPath, currResult + newDocs.length);
+  for (var i = 0; i < newDocs.length; i++) 
+    if (countQuery.filterTest(newDocs[i]))
+      belongCount++;
+
+  var resultPath = getResultPath(countQuery.id);
+  model.set(resultPath, currResult + belongCount);
 };
 
 exports.onRmDoc = function (oldDoc, countQuery, model, searchSpace, currResult) {
-  return; // TODO Figure out how best to handle count later
-
   var ns = countQuery.ns
     , doesBelong = countQuery.filterTest(oldDoc, ns);
   if (! doesBelong) return;
+
   var resultPath = getResultPath(countQuery.id);
   model.set(resultPath, currResult - 1);
 };
 
 exports.onUpdateDocProperty = function (doc, countQuery, model, searchSpace, currResult) {
-  return; // TODO Figure out how best to handle count later
-  var resultPath = getResultPath(countQuery.id)
-    , count = countQuery.syncRun(searchSpace);
-  model.set(resultPath, count);
+  var ns = countQuery.ns
+    , resultPath = getResultPath(countQuery.id);
+
+  if (!isSpeculative(doc)) {
+    model.set(resultPath, countQuery.syncRun(searchSpace));
+    return;
+  }
+  // If the doc is a speculative change
+  // of the base model, we can check if
+  // the new and old values are matched
+  // by the query, and update the count
+  var didBelong = countQuery.filterTest(Object.getPrototypeOf(doc), ns)
+    , doesBelong = countQuery.filterTest(doc, ns)
+
+  if (didBelong === doesBelong) // This change did not affect the query
+    return;
+
+  if (doesBelong)
+    model.set(resultPath, currResult + 1);
+  else
+    model.set(resultPath, currResult - 1);
 };
 
 exports.resultDefault = 0;


### PR DESCRIPTION
The update handlers for count queries were disabled a while ago by https://github.com/codeparty/racer/commit/cf0259395894857c27606da3302916c35326be4b

I re-enabled them and fixed every issue I could find.
Why were they disabled?  
Is there something I missed?
