### PR TITLE
pass in {req: req} from guards to access control functions

### DIFF
--- a/lib/accessControl/accessControl.Store.js
+++ b/lib/accessControl/accessControl.Store.js
@@ -156,7 +156,7 @@ function createPathGuard (pattern, callback) {
     if (!regexp.test(path)) return next();
     req.didMatchAGuard = true
     var captures = regexp.exec(path).slice(1)
-      , caller = {session: session};
+      , caller = {session: session, req: req};
     callback.apply(caller, captures.concat([function (isAllowed) {
       if (!isAllowed) return res.fail('403 Unauthorized');
       return next();
@@ -192,7 +192,7 @@ function createQueryGuard (ns, motif, callback) {
     req.matchingGuardFor[matchingMotif] = true;
 
     var args = motifs[matchingMotif];
-    var caller = {session: req.session};
+    var caller = {session: req.session, req: req};
     callback.apply(caller, args.concat([function (isAllowed) {
       if (!isAllowed) return res.fail('403 Unauthorized');
       return next();
@@ -219,7 +219,7 @@ function createWriteGuard (mutator, target, callback) {
     var captures = regexp.exec(path).slice(1);
     var args = transaction.getArgs(txn).slice(1); // ignore path
 
-    var caller = {session: req.session};
+    var caller = {session: req.session, req: req};
 
     callback.apply(caller, captures.concat(args).concat([function (isAllowed) {
       if (!isAllowed) return res.fail('403 Unauthorized', txn);


### PR DESCRIPTION
In my accessControl callbacks, I find it useful to check if the request came from the server or client. For example, I want to allow limited read/write from the browser, but limitless access from an API call given they've authenticated. The way I've been doing it is passing  `req` along with `session` (which is currently being passed) to the callbacks. Then I can just put some dummy flag on req in server routes, like `req._isServer = true`. I can't do this on `req.session` because that's not always available (eg, APIs call from a non-browser caller). 
