### PR TITLE
Cleanup data.splits

### DIFF
--- a/lib/Model.js
+++ b/lib/Model.js
@@ -37,6 +37,11 @@ function Model (init) {
 
   this.middleware = {};
   this.mixinEmit('middleware', this, this.middleware);
+
+  // Fix memory leak in treeLookup(); see https://github.com/codeparty/racer/issues/72
+  this.on('cleanup', function () {
+    this._memory._data.splits = {};
+  });
 }
 
 var modelProto = Model.prototype


### PR DESCRIPTION
I handled the model `cleanup` event to empty the `splits` cache.

This fixes #72.
