### PR TITLE
Fix path test cases

### DIFF
--- a/test/path.mocha.coffee
+++ b/test/path.mocha.coffee
@@ -13,7 +13,7 @@ testRegExps = (reList, sources, matches, nonMatches) ->
     for obj in matches[i]
       for match, captures of obj
         expect(re.exec(match).slice 1).to.eql captures
-    expect(re.test nonMatch).to.be.false for nonMatch in nonMatches[i]
+    expect(re.test nonMatch).to.not.be.ok() for nonMatch in nonMatches[i]
 
 describe 'path', ->
 


### PR DESCRIPTION
First, expect.js has no check .to.be.false, second, all expect.js asserts are functions which need to be called.
