### PR TITLE
Allow custom socket.io querystring args

### DIFF
--- a/lib/racer.browser.js
+++ b/lib/racer.browser.js
@@ -49,8 +49,11 @@ function plugin (racer) {
     racer.emit('init', model);
 
     // TODO If socket is passed into racer, make sure to add clientId query param
-    ioOptions.query = 'clientId=' + clientId;
-    model._setSocket(socket || io.connect(ioUri + '?clientId=' + clientId, ioOptions));
+    if (ioOptions.query)
+      ioOptions.query += '&clientId=' + encodeURIComponent(clientId);
+    else
+      ioOptions.query = 'clientId=' + encodeURIComponent(clientId);
+    model._setSocket(socket || io.connect(ioUri, ioOptions));
 
     IS_READY = true;
     racer.emit('ready', model);


### PR DESCRIPTION
This is useful for CSRF protection in custom handshake handlers.

You can set query strings on the server like this:

``` js
// The model._ioOptions property is a reference
// a shared object to store, so I need to clone
// it to add a per-request querystring.
model._ioOptions = Object.create(model._ioOptions);
model._ioOptions.query = "a=b&c=d";
```
