### PR TITLE
Fix for Uglify v2.3.2

### DIFF
--- a/lib/bundle/util.js
+++ b/lib/bundle/util.js
@@ -16,8 +16,8 @@ function bundledFunction (fn) {
   if (isProduction) {
     // Uglify can't parse a naked function. Executing it allows Uglify to
     // parse it properly
-    var minified = racer.get('minifyJs')('(' + fnStr + ')();');
-    fnStr = minified.slice(1, -4);
+    var minified = racer.get('minifyJs')('!' + fnStr + '();');
+    fnStr = minified.slice(1, -3);
   }
   return fnStr;
 }


### PR DESCRIPTION
Uglify v2.3.2 transforms (function(){})() to !function(){}()
This breaks the slice() call.

Fixes lefnire/habitrpg#920

This code still works with older Uglifies.
