### PR TITLE
Server produces segments where indices are integers. '===' exactly equal will fail to match pattern

### DIFF
--- a/lib/Model/events.js
+++ b/lib/Model/events.js
@@ -226,7 +226,7 @@ function testPatternFn(pattern, patternSegments) {
           captures.push(segment);
           continue;
         }
-        if (patternSegment !== segment) return;
+        if (patternSegment != segment) return;
       }
       if (endingRest) {
         var remainder = segments.slice(i).join('.');


### PR DESCRIPTION
It may be appropriate to verify that the server is producing events where each segment is a string, but listeners don't need to perform a strict equality check.

ex.
// path segments produced by the server event
segments = ["stories", 15, "title"]
// the pattern my client-side listener is set to
pattern = "stories.15.title"
