### PR TITLE
Channel send method doesn't pass arguments to callback

### DIFF
--- a/lib/Channel.js
+++ b/lib/Channel.js
@@ -34,7 +34,7 @@ Channel.prototype._reply = function(id, name, data) {
 Channel.prototype._onMessage = function(data) {
   if (data.ack) {
     var message = this.messages.remove(data.id);
-    if (message && message.cb) message.cb.apply(data.data);
+    if (message && message.cb) message.cb.apply(null, data.data);
     return;
   }
   var name = data.racer;


### PR DESCRIPTION
Fix:
`message.cb.apply(data.data)` -> `message.cb.apply(null, data.data)`
