### PR TITLE
browserify 3.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "node-uuid": "1.x",
-    "share": "0.7.x",
+    "share": "git://github.com/vmakhaev/ShareJS#master",
     "deep-is": "~0.1.1",
     "arraydiff": "~0.1.1",
     "browserify": "~3.4.0",


### PR DESCRIPTION
Racer works with browserify 2 and 3.
But https://github.com/vmakhaev/derby-log does not work with browserify 2. And I can not figure out why. Maybe we can just up browserify version?
