### PR TITLE
Enable RemoteDoc unit testing, including event checking for move

### DIFF
--- a/test/Model/RemoteDoc.mocha.coffee
+++ b/test/Model/RemoteDoc.mocha.coffee
@@ -117,9 +117,10 @@ describe 'RemoteDoc', ->
       doc.set ['array'], [0, 1, 2, 3, 4], ->
 
       events = 0
+      # the single howMany > 1 move is split into lots of howMany==1 moves
       remote.model.on 'move', (captures, [from, to, howMany, passed]) ->
         expect(from).to.equal 1
-        expect(to).to.equal 3 + events
+        expect(to).to.equal 4
         if ++events == 2
           done()
 


### PR DESCRIPTION
This pull request contains an attempt to unit test RemoteDocs.

In particular, I'm attempting to show what I believe is incorrect array move event reporting, as discussed here:
https://groups.google.com/d/msg/derbyjs/cPG3XO0kAwE/TvBA89f0ceUJ

There are currently 10 failures, but I'm keen to know whether this approach looks right!
