### PR TITLE
Update livedb-mongo in examples so that the examples work

### DIFF
--- a/examples/pad/package.json
+++ b/examples/pad/package.json
@@ -7,7 +7,7 @@
     "express": "~3.2.3",
     "handlebars": "~1.0.10",
     "racer-browserchannel": "~0.1.0",
-    "livedb-mongo": "~0.1.2",
+    "livedb-mongo": "~0.3.0",
     "redis": "~0.8.3"
   },
   "private": true

--- a/examples/todos/package.json
+++ b/examples/todos/package.json
@@ -7,7 +7,7 @@
     "express": "~3.2.3",
     "coffeeify": "~0.4.0",
     "racer-browserchannel": "~0.1.0",
-    "livedb-mongo": "~0.1.2",
+    "livedb-mongo": "~0.3.0",
     "redis": "~0.8.3"
   },
   "private": true


### PR DESCRIPTION
If you're running a recent version of mongo, the examples don't work. Updating `livedb-mongo` to v0.3.0 fixes this.
