### PR TITLE
make jshint config available outside of grunt

### DIFF
--- a/.jshintignore
+++ b/.jshintignore
@@ -1,0 +1,4 @@
+node_modules/**
+examples/**
+package.json
+

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,17 @@
+{
+  "node": true,
+  "laxcomma": true,
+  "eqnull": true,
+  "eqeqeq": true,
+  "indent": 2,
+  "newcap": true,
+  "quotmark": "single",
+  "undef": true,
+  "trailing": true,
+  "supernew": true,
+  "funcscope": true,
+  "shadow": true,
+  "expr": true,
+  "boss": true
+}
+

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,31 +1,21 @@
 module.exports = function(grunt) {
 
-  grunt.initConfig({
-    jshint: {
-      options: {
-        laxcomma: true
-      , eqnull: true
-      , eqeqeq: true
-      , indent: 2
-      , newcap: true
-      , quotmark: 'single'
-      , undef: true
-      , trailing: true
-      , supernew: true
-      , funcscope: true
-      , shadow: true
-      , expr: true
-      , node: true
-      , boss: true
+  grunt.initConfig(
+  { jshint:
+    { src:
+      [ 'Gruntfile.js'
+      , 'lib/**/*.js'
+      ]
+    , options:
+      { jshintrc: '.jshintrc'
       }
-    , all: ['Gruntfile.js', 'lib/**/*.js']
     }
-  , simplemocha: {
-      options: {
-        reporter: 'spec'
+  , simplemocha:
+    { options:
+      { reporter: 'spec'
       }
-    , all: {
-        src: 'test/**/*.mocha.coffee'
+    , all:
+      { src: 'test/**/*.mocha.coffee'
       }
     }
   });

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "expect.js": "~0.2.0",
     "coffee-script": "~1.6.2",
     "grunt-simple-mocha": "~0.4.0",
-    "grunt-contrib-jshint": "~0.4.3"
+    "grunt-contrib-jshint": "~0.8",
+    "jshint": "~2.4"
   },
   "optionalDependencies": {},
   "engines": {


### PR DESCRIPTION
I mostly just needed this for syntastic, but the Gruntfile was failing its own
jshint so I updated it too.

Of course, that may have just been because syntastic wasn't working.
Whatever. Holla if the style's wrong.
