### PR TITLE
test suite won't run without grunt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: node_js
 node_js:
   - "0.10"
-before_script:
-  - npm install -g grunt-cli
+

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "version": "0.5.14",
   "main": "./lib/index.js",
   "scripts": {
-    "test": "grunt test"
+    "test": "./node_modules/.bin/grunt test"
   },
   "dependencies": {
     "node-uuid": "1.x",
@@ -25,6 +25,7 @@
     "mocha": "~1.9.0",
     "expect.js": "~0.2.0",
     "coffee-script": "~1.6.2",
+    "grunt-cli": "^0.1.13",
     "grunt-simple-mocha": "~0.4.0",
     "grunt-contrib-jshint": "~0.4.3"
   },


### PR DESCRIPTION
...so in my book that makes it a devDependency.

It changes too frequently to be workable as global package
anyway, so just ignore the warning.
