### PR TITLE
Updated links to racer-examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,13 +19,13 @@ There are currently two demos, which are included under the examples directory. 
 
 <!-- http://pad.racerjs.com/home -->
 
-A very simple collaborative [text editor](https://github.com/codeparty/racer/tree/master/examples/pad).
+A very simple collaborative [text editor](https://github.com/codeparty/racer-examples/tree/master/pad).
 
 ### Todos
 
 <!-- http://todos.racerjs.com/home -->
 
-Classic [todo list](https://github.com/codeparty/racer/tree/master/examples/todos) demonstrating the use of Racer's model methods.
+Classic [todo list](https://github.com/codeparty/racer-examples/tree/master/todos) demonstrating the use of Racer's model methods.
 
 
 ## Features


### PR DESCRIPTION
The links in the Readme were still pointing to the examples folder instead of the new examples repo.
