### PR TITLE
bugfix: Cannot set property 'id' of null

### DIFF
--- a/lib/Model/RemoteDoc.js
+++ b/lib/Model/RemoteDoc.js
@@ -54,7 +54,7 @@ RemoteDoc.prototype = new Doc();
 
 RemoteDoc.prototype._updateCollectionData = function() {
   var snapshot = this.shareDoc.snapshot;
-  if (typeof snapshot === 'object' && !Array.isArray(snapshot)) {
+  if (typeof snapshot === 'object' && !Array.isArray(snapshot) && snapshot !== null) {
     snapshot.id = this.id;
   }
   this.collectionData[this.id] = snapshot;


### PR DESCRIPTION
In the function:

``` js
RemoteDoc.prototype._updateCollectionData = function() {
  var snapshot = this.shareDoc.snapshot;
  if (typeof snapshot === 'object' && !Array.isArray(snapshot)) {
    snapshot.id = this.id;
  }
  this.collectionData[this.id] = snapshot;
};
```

Sometimes `this.shareDoc.snapshot === null` (if there is no such a doc but we fetch/subscribe on it: `model.at('items.id1').fetch())`

**But!**

``` js
typeof null === "object" // true!!!!!!
```

So, it's a truly condition:

``` js
  if (typeof snapshot === 'object' && !Array.isArray(snapshot)) {
    snapshot.id = this.id;
  }
  // here we got:
  // null.id = this.id
```

As a result:

```
TypeError: Cannot set property 'id' of null
  at Doc.RemoteDoc._updateCollectionData (/home/zag2art/work/node-tools/community/node_modules/derby/node_modules/racer/lib/Model/RemoteDoc.js:58:17)
  at Array.subscribeDocCallback [as 0] (/home/zag2art/work/node-tools/community/node_modules/derby/node_modules/racer/lib/Model/subscriptions.js:154:11)
  at [object Object].Doc._finishSub (/home/zag2art/work/node-tools/community/node_modules/derby/node_modules/racer/node_modules/share/lib/client/doc.js:526:34)
  at [object Object].Doc._onMessage (/home/zag2art/work/node-tools/community/node_modules/derby/node_modules/racer/node_modules/share/lib/client/doc.js:287:12)
  at [object Object].Connection.handleMessage (/home/zag2art/work/node-tools/community/node_modules/derby/node_modules/racer/node_modules/share/lib/client/connection.js:215:37)
  at StreamSocket.socket.onmessage (/home/zag2art/work/node-tools/community/node_modules/derby/node_modules/racer/node_modules/share/lib/client/connection.js:124:18)
  at StreamSocket.Channel.socket.onmessage (/home/zag2art/work/node-tools/community/node_modules/derby/node_modules/racer/lib/Channel.js:19:28)
  at Duplex._write (/home/zag2art/work/node-tools/community/node_modules/derby/node_modules/racer/lib/Model/connection.server.js:23:12)
  at doWrite (_stream_writable.js:223:10)
  at writeOrBuffer (_stream_writable.js:213:5)
...
```
