### PR TITLE
bugfix: don't resubscribe if isPathQuery

### DIFF
--- a/lib/Model/Query.js
+++ b/lib/Model/Query.js
@@ -56,6 +56,11 @@ Model.prototype._initQueries = function(items) {
     queries.add(query);
 
     this._set(query.idsSegments, ids);
+    
+    if (query.isPathQuery) {
+      this._set(expression, ids);
+    }
+    
     if (extra !== void 0) {
       this._set(query.extraSegments, extra);
     }


### PR DESCRIPTION
The case:

Server rendering, unbundleing. Racer don't resubscribe to serialized docs for queries with ids-path (f.e. model.query('users', '_page.userIds')).

Racer subscribes only to new-docs (which will be added after reactive-function changes '_page.userIds'). But all serialized/deserialized '_page.userIds' docs stay without subscription.

You can try to recreate the bug using chat from derby-examples. After some chating (using two browsers or usual/incognito tabs) press f5, and then change user-name at the another tab. The name don't be changed in the first tab.
