### PR TITLE
Destroy shareDocs

### DIFF
--- a/lib/Model/subscriptions.js
+++ b/lib/Model/subscriptions.js
@@ -240,9 +240,7 @@ Model.prototype._maybeUnloadDoc = function(collectionName, id, path) {
   var previous = doc.get();
   this.root.collections[collectionName].remove(id);
 
-  // TODO: There is a bug in ShareJS where a race condition between subscribe
-  // and destroying the document data. For now, not cleaning up ShareJS docs
-  // if (doc.shareDoc) doc.shareDoc.destroy();
+  if (doc.shareDoc) doc.shareDoc.destroy();
 
   delete this.root._loadVersions[path];
   this.emit('unload', [collectionName, id], [previous, this._pass]);


### PR DESCRIPTION
It fixed #189 (doubles in the view) and memory leaks. And of course we should fix share 'race condition' destroy bug.
