### PR TITLE
query api change

### DIFF
--- a/lib/Model/Query.js
+++ b/lib/Model/Query.js
@@ -17,9 +17,7 @@ Model.INITS.push(function(model) {
         query._onChange(ids, previousIds);
       }
       else if (query.idsPath && query.shareQuery && util.mayImpact(query.idsPath, segments)) {
-        var ids = pathIds(model, query.idsPath);
-        var previousIds = model._get(query.idsSegments);
-        query._onChange(ids, previousIds);
+        query.fetch();
       }
     }
   });


### PR DESCRIPTION
Adding a new query feature:

Old way

``` coffeescript
usersQuery = model.query 'users', '_page.userIds'
```

New:

``` coffeescript
usersQuery = model.query 'users', { id: '_page.userIds' }
```

This new way would allow ordering/filtering the data set on the server. For the moment the filter/sort is a bit broken on the client (there is a delay) and this would work around that, although sort should probably be fixed too.

I suppose this would be a bit more efficient and (arguably) would make the api a bit more unified too. IMO, this would be a little more clean than `'users', '_page.userIds'` way.

So this should allow queries like:

``` coffeescript
usersQuery = model.query 'users', { id: '_page.userIds', "$orderby": { created_at : -1 } }
```
