### PR TITLE
query method works wrong if you call it not on root model

### DIFF
--- a/lib/Model/Query.js
+++ b/lib/Model/Query.js
@@ -32,7 +32,7 @@ Model.prototype.query = function(collectionName, expression, source) {
   }
   var query = this.root._queries.get(collectionName, expression, source);
   if (query) return query;
-  query = new Query(this, collectionName, expression, source);
+  query = new Query(this.root, collectionName, expression, source);
   this.root._queries.add(query);
   return query;
 };


### PR DESCRIPTION
I guess we should pass root model to Query constructor