### PR TITLE
Add disableSubmit and remoteMutations debugging options

### DIFF
--- a/lib/Model/Model.js
+++ b/lib/Model/Model.js
@@ -9,6 +9,7 @@ function Model(options) {
 
   var inits = Model.INITS;
   options || (options = {});
+  this.debug = options.debug || {};
   for (var i = 0; i < inits.length; i++) {
     inits[i](this, options);
   }

--- a/lib/Model/RemoteDoc.js
+++ b/lib/Model/RemoteDoc.js
@@ -14,6 +14,10 @@ module.exports = RemoteDoc;
 function RemoteDoc(model, collectionName, id, data) {
   Doc.call(this, model, collectionName, id);
   var shareDoc = this.shareDoc = model._getOrCreateShareDoc(collectionName, id, data);
+  if (model.root.debug.disableSubmit) {
+    shareDoc.submitOp = function() {};
+  }
+  this.debugMutations = model.root.debug.remoteMutations;
   this.createdLocally = false;
   this.model = model = model.pass({$remote: true});
   this._updateCollectionData();
@@ -61,6 +65,9 @@ RemoteDoc.prototype._updateCollectionData = function() {
 };
 
 RemoteDoc.prototype.set = function(segments, value, cb) {
+  if (this.debugMutations) {
+    console.log('RemoteDoc set', this.path(segments), value);
+  }
   if (segments.length === 0 && !this.shareDoc.type) {
     // We copy the snapshot at time of create to prevent the id added outside
     // of ShareJS from getting stored in the data
@@ -89,6 +96,9 @@ RemoteDoc.prototype.set = function(segments, value, cb) {
 };
 
 RemoteDoc.prototype.del = function(segments, cb) {
+  if (this.debugMutations) {
+    console.log('RemoteDoc del', this.path(segments));
+  }
   if (segments.length === 0) {
     var previous = this.get();
     this.shareDoc.del(cb);
@@ -109,6 +119,9 @@ RemoteDoc.prototype.del = function(segments, cb) {
 };
 
 RemoteDoc.prototype.increment = function(segments, byNumber, cb) {
+  if (this.debugMutations) {
+    console.log('RemoteDoc increment', this.path(segments), byNumber);
+  }
   var previous = this._createImplied(segments);
   if (previous instanceof ImpliedOp) {
     var lastSegment = segments[segments.length - 1];
@@ -133,6 +146,9 @@ RemoteDoc.prototype.increment = function(segments, byNumber, cb) {
 };
 
 RemoteDoc.prototype.push = function(segments, value, cb) {
+  if (this.debugMutations) {
+    console.log('RemoteDoc push', this.path(segments), value);
+  }
   var shareDoc = this.shareDoc;
   function push(arr, fnCb) {
     var op = [new ListInsertOp(segments, arr.length, value)];
@@ -143,6 +159,9 @@ RemoteDoc.prototype.push = function(segments, value, cb) {
 };
 
 RemoteDoc.prototype.unshift = function(segments, value, cb) {
+  if (this.debugMutations) {
+    console.log('RemoteDoc unshift', this.path(segments), value);
+  }
   var shareDoc = this.shareDoc;
   function unshift(arr, fnCb) {
     var op = [new ListInsertOp(segments, 0, value)];
@@ -153,6 +172,9 @@ RemoteDoc.prototype.unshift = function(segments, value, cb) {
 };
 
 RemoteDoc.prototype.insert = function(segments, index, values, cb) {
+  if (this.debugMutations) {
+    console.log('RemoteDoc insert', this.path(segments), index, values);
+  }
   var shareDoc = this.shareDoc;
   function insert(arr, fnCb) {
     var op = createInsertOp(segments, index, values);
@@ -174,6 +196,9 @@ function createInsertOp(segments, index, values) {
 }
 
 RemoteDoc.prototype.pop = function(segments, cb) {
+  if (this.debugMutations) {
+    console.log('RemoteDoc pop', this.path(segments));
+  }
   var shareDoc = this.shareDoc;
   function pop(arr, fnCb) {
     var index = arr.length - 1;
@@ -186,6 +211,9 @@ RemoteDoc.prototype.pop = function(segments, cb) {
 };
 
 RemoteDoc.prototype.shift = function(segments, cb) {
+  if (this.debugMutations) {
+    console.log('RemoteDoc shift', this.path(segments));
+  }
   var shareDoc = this.shareDoc;
   function shift(arr, fnCb) {
     var value = arr[0];
@@ -197,6 +225,9 @@ RemoteDoc.prototype.shift = function(segments, cb) {
 };
 
 RemoteDoc.prototype.remove = function(segments, index, howMany, cb) {
+  if (this.debugMutations) {
+    console.log('RemoteDoc remove', this.path(segments), index, howMany);
+  }
   var shareDoc = this.shareDoc;
   function remove(arr, fnCb) {
     var values = arr.slice(index, index + howMany);
@@ -211,6 +242,9 @@ RemoteDoc.prototype.remove = function(segments, index, howMany, cb) {
 };
 
 RemoteDoc.prototype.move = function(segments, from, to, howMany, cb) {
+  if (this.debugMutations) {
+    console.log('RemoteDoc move', this.path(segments), from, to, howMany);
+  }
   var shareDoc = this.shareDoc;
   function move(arr, fnCb) {
     // Get the return value
@@ -229,6 +263,9 @@ RemoteDoc.prototype.move = function(segments, from, to, howMany, cb) {
 };
 
 RemoteDoc.prototype.stringInsert = function(segments, index, value, cb) {
+  if (this.debugMutations) {
+    console.log('RemoteDoc stringInsert', this.path(segments), index, value);
+  }
   var previous = this._createImplied(segments);
   if (previous instanceof ImpliedOp) {
     var lastSegment = segments[segments.length - 1];
@@ -253,6 +290,9 @@ RemoteDoc.prototype.stringInsert = function(segments, index, value, cb) {
 };
 
 RemoteDoc.prototype.stringRemove = function(segments, index, howMany, cb) {
+  if (this.debugMutations) {
+    console.log('RemoteDoc stringRemove', this.path(segments), index, howMany);
+  }
   var previous = this._createImplied(segments);
   if (previous instanceof ImpliedOp) return;
   if (previous == null) return previous;


### PR DESCRIPTION
cc @nateps 

Added two useful debugging options:
* `disableSubmit` - no operations will actually be submitted. This is useful for when you want to ensure you are not modifying data (like in a data audit).
* `remoteMutations` - verbose logging of mutations on remote documents. This is useful when you want to see what racer will modify via ShareJS. Can also be used to just see what racer will do when used with `disableSubmit` without making actual changes.