### PR TITLE
enable updateIndices by default

### DIFF
--- a/lib/Model/ref.js
+++ b/lib/Model/ref.js
@@ -274,7 +274,7 @@ function Ref(model, from, to, options) {
     var parentTo = this.toSegments.slice(0, i).join('.');
     this.parentTos.push(parentTo);
   }
-  this.updateIndices = options && options.updateIndices;
+  this.updateIndices = options && options.updateIndices !== false;
 }
 function FromMap() {}
 function ToMap() {}


### PR DESCRIPTION
Why is `updateIndices` disabled by default? Performance?

All [tests pass](https://travis-ci.org/wenzowski/racer/builds/53244062) but do not merge this as-is: if merging tests should be updated to reflect change in defaults.

closes derbyjs/derby#483