### PR TITLE
When calling model.subscribe with identical queries prior to data being ...

### DIFF
--- a/lib/Model/Query.js
+++ b/lib/Model/Query.js
@@ -249,8 +249,11 @@ Query.prototype.subscribe = function(cb) {
   if (this.subscribeCount++) {
     process.nextTick(function() {
       var data = query.model._get(query.segments);
-      if (data) cb();
-      else query._pendingSubscribeCallbacks.push(cb);
+      if (data) {
+        cb();
+      } else {
+        query._pendingSubscribeCallbacks.push(cb);
+      }
     });
     return this;
   }
@@ -273,15 +276,19 @@ Query.prototype.subscribe = function(cb) {
   options.docMode = 'fetch';
   model.root.shareConnection.createFetchQuery(
     this.collectionName, this.sourceQuery(), options, function(err, results, extra) {
-      if (err) return cb(err);
+      if (err) {
+        cb(err);
+        query._flushPendingCallbacks(err);
+        return;
+      }
       var ids = resultsIds(results);
       if (extra !== void 0) {
         model._setDiffDeep(query.extraSegments, extra);
       }
-      query._onChange(ids, null, cb);
-      while (cb = query._pendingSubscribeCallbacks.shift()) {
-        query._onChange(ids, null, cb);
-      }
+      query._onChange(ids, null, function(err) {
+        cb(err);
+        query._flushPendingCallbacks(err);
+      });
     }
   );
   return this;
@@ -300,13 +307,18 @@ Query.prototype._shareSubscribe = function(options, cb) {
   var model = this.model;
   this.shareQuery = this.model.root.shareConnection.createSubscribeQuery(
     this.collectionName, this.sourceQuery(), options, function(err, results, extra) {
-      if (err) return cb(err);
+      if (err) {
+        cb(err);
+        query._flushPendingCallbacks();
+        return;
+      }
       if (extra !== void 0) {
         model._setDiffDeep(query.extraSegments, extra);
       }
       // Results are not set in the callback, because the shareQuery should
       // emit a 'change' event before calling back
       cb();
+      query._flushPendingCallbacks();
     }
   );
   var query = this;
@@ -328,6 +340,19 @@ Query.prototype._shareSubscribe = function(options, cb) {
   this.shareQuery.on('extra', function(extra) {
     model._setDiffDeep(query.extraSegments, extra);
   });
+};
+
+/**
+ * Flushes `_pendingSubscribeCallbacks`, calling each callback in the array,
+ * with an optional error to pass into each. `_pendingSubscribeCallbacks` will
+ * be empty after this runs.
+ * @private
+ */
+Query.prototype._flushPendingCallbacks = function(err) {
+  var pendingCallback;
+  while (pendingCallback = this._pendingSubscribeCallbacks.shift()) {
+    pendingCallback(err);
+  }
 };
 
 /**


### PR DESCRIPTION
...returned, make sure all the callbacks are called.

@nateps 