### PR TITLE
Do not allow creates or deletes when disableSubmit flag is set

### DIFF
--- a/lib/Model/RemoteDoc.js
+++ b/lib/Model/RemoteDoc.js
@@ -41,6 +41,8 @@ RemoteDoc.prototype._initShareDoc = function() {
   // Override submitOp to disable all writes and perform a dry-run
   if (model.root.debug.disableSubmit) {
     shareDoc.submitOp = function() {};
+    shareDoc.create = function() {};
+    shareDoc.del = function() {};
   }
   // Subscribe to doc events
   shareDoc.on('op', function(op, isLocal) {


### PR DESCRIPTION
When creating a model with debug flag `disableSubmit` would expect that no operations performed on that model will actually update data in database. However, currently documents will be created and deleted even if the flag is set.

