### PR TITLE
Added the ability to use scope and functions as the skip and limit option

### DIFF
--- a/lib/Model/filter.js
+++ b/lib/Model/filter.js
@@ -162,10 +162,28 @@ Filter.prototype.sort = function(fn) {
 
 Filter.prototype._slice = function(results) {
   if (this.skip == null && this.limit == null) return results;
-  var begin = this.skip || 0;
+  var skip;
+  if (this.skip instanceof Model) {
+    skip = this.skip.get();
+  } else if (typeof this.skip === 'function') {
+    skip = this.skip();
+  } else {
+    skip = this.skip;
+  }
+  var begin = skip || 0;
   // A limit of zero is equivalent to setting no limit
   var end;
-  if (this.limit) end = begin + this.limit;
+  if (this.limit) {
+    var limit;
+    if (this.limit instanceof Model) {
+      limit = this.limit.get();
+    } else if (typeof this.limit === 'function') {
+      limit = this.limit();
+    } else {
+      limit = this.limit;
+    }
+    end = begin + limit;
+  }
   return results.slice(begin, end);
 };
 


### PR DESCRIPTION
Now you can use scopes and functions as limit and skip options in filter. You can do pagination like this:

    {
      limit: model.root.at('_session.cards_in_page'), 
      skip: function(){ 
        model.root.get('_page.page_index') * model.root.get('_session.cards_in_page') 
      }
    }
