### PR TITLE
Add option to unsubscribe or unfetch from a model or query immediately

### DIFF
--- a/lib/Model/Query.js
+++ b/lib/Model/Query.js
@@ -386,7 +386,7 @@ Query.prototype._flushSubscribeCallbacks = function(cb, err) {
   }
 };
 
-Query.prototype.unfetch = function(cb) {
+Query.prototype.unfetch = function(cb, immediate) {
   cb = this.model.wrapCallback(cb);
   this.model._context.unfetchQuery(this);
 
@@ -397,7 +397,7 @@ Query.prototype.unfetch = function(cb) {
   }
 
   var query = this;
-  if (this.model.root.unloadDelay) {
+  if (this.model.root.unloadDelay && !immediate) {
     setTimeout(finishUnfetchQuery, this.model.root.unloadDelay);
   } else {
     finishUnfetchQuery();
@@ -412,7 +412,7 @@ Query.prototype.unfetch = function(cb) {
   return this;
 };
 
-Query.prototype.unsubscribe = function(cb) {
+Query.prototype.unsubscribe = function(cb, immediate) {
   cb = this.model.wrapCallback(cb);
   this.model._context.unsubscribeQuery(this);
 
@@ -423,7 +423,7 @@ Query.prototype.unsubscribe = function(cb) {
   }
 
   var query = this;
-  if (this.model.root.unloadDelay) {
+  if (this.model.root.unloadDelay && !immediate) {
     setTimeout(finishUnsubscribeQuery, this.model.root.unloadDelay);
   } else {
     finishUnsubscribeQuery();

--- a/lib/Model/subscriptions.js
+++ b/lib/Model/subscriptions.js
@@ -31,22 +31,33 @@ Model.prototype.unsubscribe = function() {
 };
 
 Model.prototype._forSubscribable = function(argumentsObject, method) {
-  var args, cb;
+  var args, cb, immediate;
   if (!argumentsObject.length) {
     // Use this model's scope if no arguments
     args = [null];
+  } else if (argumentsObject[0] === 'boolean') {
+    // Use this model's scope if the first argument is the `immediate` boolean
+    args = [null];
+    immediate = argumentsObject[0];
   } else if (typeof argumentsObject[0] === 'function') {
     // Use this model's scope if the first argument is a callback
     args = [null];
     cb = argumentsObject[0];
+    immediate = argumentsObject[1];
   } else if (Array.isArray(argumentsObject[0])) {
     // Items can be passed in as an array
     args = argumentsObject[0];
     cb = argumentsObject[1];
+    immediate = argumentsObject[2];
   } else {
     // Or as multiple arguments
     args = Array.prototype.slice.call(argumentsObject);
-    var last = args[args.length - 1];
+    var lastIndex = args.length - 1;
+    var last = args[lastIndex];
+    if (last === true) {
+      immediate = args.pop();
+      last = args[lastIndex - 1];
+    }
     if (typeof last === 'function') cb = args.pop();
   }
 
@@ -62,11 +73,11 @@ Model.prototype._forSubscribable = function(argumentsObject, method) {
       var segments = this._dereference(this._splitPath(item));
       if (segments.length === 2) {
         // Do the appropriate method for a single document.
-        this[docMethod](segments[0], segments[1], group());
+        this[docMethod](segments[0], segments[1], group(), immediate);
       } else if (segments.length === 1) {
         // Make a query to an entire collection.
         var query = this.query(segments[0], {});
-        query[method](group());
+        query[method](group(), immediate);
       } else if (segments.length === 0) {
         group()(new Error('No path specified for ' + method));
       } else {
@@ -110,7 +121,7 @@ Model.prototype.subscribeDoc = function(collectionName, id, cb) {
   }
 };
 
-Model.prototype.unfetchDoc = function(collectionName, id, cb) {
+Model.prototype.unfetchDoc = function(collectionName, id, cb, immediate) {
   cb = this.wrapCallback(cb);
   this._context.unfetchDoc(collectionName, id);
 
@@ -118,7 +129,7 @@ Model.prototype.unfetchDoc = function(collectionName, id, cb) {
   if (!this.root._fetchedDocs.get(collectionName, id)) return cb();
 
   var model = this;
-  if (this.root.unloadDelay) {
+  if (this.root.unloadDelay && !immediate) {
     setTimeout(finishUnfetchDoc, this.root.unloadDelay);
   } else {
     finishUnfetchDoc();
@@ -131,7 +142,7 @@ Model.prototype.unfetchDoc = function(collectionName, id, cb) {
   }
 };
 
-Model.prototype.unsubscribeDoc = function(collectionName, id, cb) {
+Model.prototype.unsubscribeDoc = function(collectionName, id, cb, immediate) {
   cb = this.wrapCallback(cb);
   this._context.unsubscribeDoc(collectionName, id);
 
@@ -139,7 +150,7 @@ Model.prototype.unsubscribeDoc = function(collectionName, id, cb) {
   if (!this.root._subscribedDocs.get(collectionName, id)) return cb();
 
   var model = this;
-  if (this.root.unloadDelay) {
+  if (this.root.unloadDelay && !immediate) {
     setTimeout(finishUnsubscribeDoc, this.root.unloadDelay);
   } else {
     finishUnsubscribeDoc();


### PR DESCRIPTION
This pull request allows a model or query to ignore [`model.root.unloadDelay`](https://github.com/derbyjs/racer/blob/cb44c8c962963fdab5a95ef8575331d5505fc44d/lib/Model/subscriptions.js#L8) when unsubscribing or unfetching.

`model.unsubscribe` and `model.unfetch` now have the function signatures:
```
model.subscribe(items..., callback(err), immediate)
model.unfetch(items..., callback(err), immediate)
```
* **items:** [[unchanged]](http://derbyjs.com/docs/derby-0.6/models/backends#loading-data-into-a-model)
* **callback:** [[unchanged]](http://derbyjs.com/docs/derby-0.6/models/backends#loading-data-into-a-model)
* **immediate:** *(boolean)* If `true`, immediately unsubscribe/unfetch the items without a delay (`model.root.unloadDelay`)

As a result of this change, it's possible to unsubscribe and subsequently resubscribe to the same collection (with different database queries) without waiting for `model.root.unloadDelay` to time out.