### PR TITLE
Add deep copy to avoid duplicate ops when composing a created doc

### DIFF
--- a/lib/Model/RemoteDoc.js
+++ b/lib/Model/RemoteDoc.js
@@ -96,7 +96,7 @@ RemoteDoc.prototype.create = function(value, cb) {
   }
   // We copy the snapshot at time of create to prevent the id added outside
   // of ShareJS from getting stored in the data
-  var snapshot = util.copy(value);
+  var snapshot = util.deepCopy(value);
   if (snapshot) delete snapshot.id;
   this.shareDoc.create('json0', snapshot, cb);
   // The id value will get added to the snapshot that was passed in


### PR DESCRIPTION
@nateps 

In Share the create doc and the snapshot are different objects and during the tryCompose the operation is applied to the create doc and then _otApply applied the op to the snapshot. Because racer only made a shallow copy, the op was getting applied twice.