### PR TITLE
Make the pattern chunk match non strict.

### DIFF
--- a/lib/Model/events.js
+++ b/lib/Model/events.js
@@ -287,7 +287,7 @@ function testPatternFn(pattern, patternSegments) {
           captures.push(segment);
           continue;
         }
-        if (patternSegment !== segment) return;
+        if (patternSegment != segment) return;
       }
       if (endingRest) {
         var remainder = segments.slice(i).join('.');


### PR DESCRIPTION
Now it doesn't match events for paths like this: '_page.coll.12.field', because third chunk 12 (number) is compared to pattern '12' (string). But it can be fixed by making equality non strict.
