### PR TITLE
When creating implied operation detect case where we need to replace …

### DIFF
--- a/lib/Model/RemoteDoc.js
+++ b/lib/Model/RemoteDoc.js
@@ -354,9 +354,15 @@ RemoteDoc.prototype._createImplied = function(segments) {
         value = value[key] = util.isArrayIndex(nextKey) ? [] : {};
       } else {
         value = util.isArrayIndex(nextKey) ? [] : {};
-        op = (Array.isArray(parent)) ?
-          new ListInsertOp(segments.slice(0, i - 2), key, value) :
-          new ObjectInsertOp(segments.slice(0, i - 1), value);
+        if (Array.isArray(parent)) {
+          if (key >= parent.length) {
+            op = new ListInsertOp(segments.slice(0, i - 2), key, value);
+          } else {
+            op = new ListReplaceOp(segments.slice(0, i - 2), key, node, value);
+          }
+        } else {
+          op = new ObjectInsertOp(segments.slice(0, i - 1), value);
+        }
       }
       node = value;
     }


### PR DESCRIPTION
…null values in an array


This fixes a bug where when creating an implied operation on an array with null values, a ListInsert operation was erroneously created.

 i.e. for the following value  `[null, null, {value:3}]` attempting to set an object at the 0th index of the array would result in the object instead being pushed to the end of the array