### PR TITLE
Fix connect dependency in 0.3 branch

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "uglify-js": "2.x",
     "node-uuid": "1.3.3",
     "hooks": "0.2.1",
-    "connect": "2.x",
+    "connect": "2.x <2.14",
     "debug": ">=0.7.0",
     "ansi-color": ">=0.2.1",
     "cookie": "0.0.4",


### PR DESCRIPTION
Make sure no connect version with 29a35531458fcfd3478640325c4e2a844eb8736 is pulled.
