### PR TITLE
fixed Doc.path() never adding the segments

### DIFF
--- a/lib/Model/Doc.js
+++ b/lib/Model/Doc.js
@@ -8,7 +8,7 @@ function Doc(model, collectionName, id) {
 
 Doc.prototype.path = function(segments) {
   var path = this.collectionName + '.' + this.id;
-  if (segments && segments.lenth) path += '.' + segments.join('.');
+  if (segments && segments.length) path += '.' + segments.join('.');
   return path;
 };
 


### PR DESCRIPTION
seems to be a minor one, since the method is currently only used in messages and exceptions