### PR TITLE
Change Query.idMap to count ids, to be defensive against duplicate ids in query results

### DIFF
--- a/lib/Model/Query.js
+++ b/lib/Model/Query.js
@@ -317,8 +317,7 @@ Query.prototype._removeMapIds = function(ids) {
 Query.prototype._addMapIds = function(ids) {
   for (var i = ids.length; i--;) {
     var id = ids[i];
-    this.idMap[id] = this.idMap[id] || 0;
-    this.idMap[id]++;
+    this.idMap[id] = (this.idMap[id] || 0) + 1;
   }
 };
 Query.prototype._diffMapIds = function(ids) {

--- a/lib/Model/Query.js
+++ b/lib/Model/Query.js
@@ -158,7 +158,7 @@ function Query(model, collectionName, expression, options) {
   // because otherwise maybeUnload would be looping through the entire results
   // set of each query on the same collection for every doc checked
   //
-  // Map of id -> true
+  // Map of id -> count of ids
   this.idMap = {};
 }
 
@@ -293,7 +293,12 @@ Query.prototype._shareSubscribe = function(options, cb) {
 Query.prototype._removeMapIds = function(ids) {
   for (var i = ids.length; i--;) {
     var id = ids[i];
-    delete this.idMap[id];
+    if (this.idMap[id] > 0) {
+      this.idMap[id]--;
+    }
+    if (this.idMap[id] === 0) {
+      delete this.idMap[id];
+    }
   }
   // Technically this isn't quite right and we might not wait the full unload
   // delay if someone else calls maybeUnload for the same doc id. However,
@@ -312,7 +317,8 @@ Query.prototype._removeMapIds = function(ids) {
 Query.prototype._addMapIds = function(ids) {
   for (var i = ids.length; i--;) {
     var id = ids[i];
-    this.idMap[id] = true;
+    this.idMap[id] = this.idMap[id] || 0;
+    this.idMap[id]++;
   }
 };
 Query.prototype._diffMapIds = function(ids) {

--- a/lib/Model/Query.js
+++ b/lib/Model/Query.js
@@ -293,10 +293,9 @@ Query.prototype._shareSubscribe = function(options, cb) {
 Query.prototype._removeMapIds = function(ids) {
   for (var i = ids.length; i--;) {
     var id = ids[i];
-    if (this.idMap[id] > 0) {
+    if (this.idMap[id] > 1) {
       this.idMap[id]--;
-    }
-    if (this.idMap[id] === 0) {
+    } else {
       delete this.idMap[id];
     }
   }

--- a/lib/Model/subscriptions.js
+++ b/lib/Model/subscriptions.js
@@ -191,7 +191,7 @@ Model.prototype._hasDocReferences = function(collectionName, id) {
     for (var hash in queries) {
       var query = queries[hash];
       if (!query.subscribeCount && !query.fetchCount) continue;
-      if (query.idMap[id]) return true;
+      if (query.idMap[id] > 0) return true;
     }
   }
 

--- a/test/Model/query.js
+++ b/test/Model/query.js
@@ -1,4 +1,5 @@
 var expect = require('../util').expect;
+var racer = require('../../lib');
 var Model = require('../../lib/Model');
 
 describe('query', function() {
@@ -12,6 +13,31 @@ describe('query', function() {
       var model = new Model();
       var query = model.query('foo', [{x: undefined}, {x: {y: undefined, z: 0}}]);
       expect(query.expression).eql([{x: null}, {x: {y: null, z: 0}}]);
+    });
+  });
+
+  describe('idMap', function() {
+    beforeEach('create in-memory backend and model', function() {
+      this.backend = racer.createBackend();
+      this.model = this.backend.createModel();
+    });
+    it('handles insert and remove of a duplicate id', function() {
+      var query = this.model.query('myCollection', {key: 'myVal'});
+      query.subscribe();
+      query.shareQuery.emit('insert', [
+        {id: 'a'},
+        {id: 'b'},
+        {id: 'c'},
+      ], 0);
+      // Add and immediately remove a duplicate id.
+      query.shareQuery.emit('insert', [
+        {id: 'a'},
+      ], 3);
+      query.shareQuery.emit('remove', [
+        {id: 'a'},
+      ], 3);
+      // 'a' is still present once in the results, should still be in the map.
+      expect(query.idMap).to.only.have.keys(['a', 'b', 'c']);
     });
   });
 });


### PR DESCRIPTION
There's a [ShareDB issue](https://github.com/share/sharedb-mongo/issues/55) where a subscribed ShareDB query can emit an insert event with an id that's already present in the result list. ShareDB then immediately emits an event (usually remove) to fix the duplication, but because the Racer query's `idMap` didn't keep track of id counts, it would mistakenly remove the id when the id's count went from 2 to 1. That causes the doc to become unloaded, since Racer uses the `idMap` to determine if any queries are subscribed to the doc.

The underlying ShareDB issue requires more investigation to fix, but Racer should still be defensive about it, especially since the issue results in Racer becoming internally inconsistent:

```
> query.getIds()
[ 'f6...',
  'c8...',
  'a3...',
  '37...' ]
> query.get()
[ undefined, undefined, undefined, undefined ]
> query.idMap
{}
```