### PR TITLE
Dedupe queries when unbundling (_initQueries)

### DIFF
--- a/lib/Model/Query.js
+++ b/lib/Model/Query.js
@@ -55,8 +55,12 @@ Model.prototype._initQueries = function(items) {
     var results = item[3] || [];
     var options = item[4];
     var extra = item[5];
-    var query = new Query(this, collectionName, expression, options);
-    queries.add(query);
+    var query = this.root._queries.get(collectionName, expression, options);
+    if (!query) {
+      query = new Query(this, collectionName, expression, options);
+      queries.add(query);
+    }
+
     query._setExtra(extra);
 
     var ids = [];

--- a/test/Model/unbundle.js
+++ b/test/Model/unbundle.js
@@ -1,0 +1,39 @@
+var expect = require('../util').expect;
+var racer = require('../../lib/index');
+
+describe('unbundle', function() {
+  it('dedupes against existing queries', function(done) {
+    var backend = racer.createBackend();
+    var setupModel = backend.createModel();
+    setupModel.add('dogs', {id: 'fido', name: 'Fido'});
+    setupModel.whenNothingPending(function() {
+      var model1 = backend.createModel({fetchOnly: true});
+      var model1Query = model1.query('dogs', {});
+      model1.subscribe(model1Query, function() {
+        model1.bundle(function(err, bundleData) {
+          if (err) {
+            return done(err);
+          }
+          // Simulate serialization of bundle data between server and client.
+          bundleData = JSON.parse(JSON.stringify(bundleData));
+
+          var model2 = backend.createModel();
+          // Unbundle should load data into model.
+          model2.unbundle(bundleData);
+          expect(model2.get('dogs.fido.name')).to.eql('Fido');
+          // Unloaded data available until after `unloadDelay` ms has elapsed.
+          model2.unloadDelay = 4;
+          model2.unload();
+          expect(model2.get('dogs.fido.name')).to.eql('Fido');
+          // Another unbundle should re-increment subscribe count, so the data
+          // should still be present even after `unloadDelay` has passed.
+          model2.unbundle(bundleData);
+          setTimeout(function() {
+            expect(model2.get('dogs.fido.name')).to.eql('Fido');
+            done();
+          }, 8);
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
This allows `model._initQueries` and by extension `model.unbundle` to be called multiple times, with fetch/subscribe counting incrementing appropriately each time. This matches the behavior of doc fetch/subscribe counting in `model.unbundle`.

Previously, new queries would be created every time `_initQueries` was called, which mean the fetch/subscribe counts got reset.