### PR TITLE
Add Model#_getOrCreateQuery method

### DIFF
--- a/lib/Model/Query.js
+++ b/lib/Model/Query.js
@@ -9,15 +9,30 @@ Model.INITS.push(function(model) {
 });
 
 Model.prototype.query = function(collectionName, expression, options) {
-  expression = this.sanitizeQuery(expression);
   // DEPRECATED: Passing in a string as the third argument specifies the db
   // option for backward compatibility
   if (typeof options === 'string') {
     options = {db: options};
   }
+  return this._getOrCreateQuery(collectionName, expression, options, Query);
+};
+
+/**
+ * If an existing query is present with the same `collectionName`, `expression`,
+ * and `options`, then returns the existing query; otherwise, constructs and
+ * returns a new query using `QueryConstructor`.
+ *
+ * @param {string} collectionName
+ * @param {*} expression
+ * @param {*} options
+ * @param {new (model: Model, collectionName: string, expression: any, options: any) => Query} QueryConstructor -
+ *   constructor function for a Query, to create one if not already present on this model
+ */
+Model.prototype._getOrCreateQuery = function(collectionName, expression, options, QueryConstructor) {
+  expression = this.sanitizeQuery(expression);
   var query = this.root._queries.get(collectionName, expression, options);
   if (query) return query;
-  query = new Query(this, collectionName, expression, options);
+  query = new QueryConstructor(this, collectionName, expression, options);
   this.root._queries.add(query);
   return query;
 };


### PR DESCRIPTION
This behaves exactly like the existing `Model#query`, except that it accepts a Query constructor function to use, allowing subclasses of Query to be utilized.