### PR TITLE
Implement async option for model.start()

### DIFF
--- a/lib/Model/fn.js
+++ b/lib/Model/fn.js
@@ -160,7 +160,7 @@ function Fn(model, name, from, inputPaths, fns, options) {
   this.mode = (options && options.mode) || 'diffDeep';
 
   this.async = !!(options && options.async);
-  this.eventDelayed = false;
+  this.eventPending = false;
 }
 
 Fn.prototype.apply = function(fn, inputs) {
@@ -189,12 +189,12 @@ Fn.prototype.set = function(value, pass) {
 
 Fn.prototype.onInput = function(pass) {
   if (this.async) {
-    if (this.eventDelayed) return;
-    this.eventDelayed = true;
+    if (this.eventPending) return;
+    this.eventPending = true;
     var fn = this;
     process.nextTick(function() {
       fn._onInput(pass);
-      fn.eventDelayed = false;
+      fn.eventPending = false;
     });
     return;
   }

--- a/lib/Model/fn.js
+++ b/lib/Model/fn.js
@@ -158,6 +158,9 @@ function Fn(model, name, from, inputPaths, fns, options) {
 
   // Mode can be 'diffDeep', 'diff', 'arrayDeep', or 'array'
   this.mode = (options && options.mode) || 'diffDeep';
+
+  this.async = !!(options && options.async);
+  this.eventDelayed = false;
 }
 
 Fn.prototype.apply = function(fn, inputs) {
@@ -185,6 +188,20 @@ Fn.prototype.set = function(value, pass) {
 };
 
 Fn.prototype.onInput = function(pass) {
+  if (this.async) {
+    if (this.eventDelayed) return;
+    this.eventDelayed = true;
+    var fn = this;
+    process.nextTick(function() {
+      fn._onInput(pass);
+      fn.eventDelayed = false;
+    });
+    return;
+  }
+  return this._onInput(pass);
+};
+
+Fn.prototype._onInput = function(pass) {
   var value = (this.copyOutput) ? util.deepCopy(this.get()) : this.get();
   this._setValue(this.model.pass(pass, true), this.fromSegments, value);
   return value;

--- a/lib/Model/fn.js
+++ b/lib/Model/fn.js
@@ -109,7 +109,7 @@ Fns.prototype.start = function(name, path, inputPaths, fns, options) {
   fns || (fns = this.nameMap[name] || defaultFns[name]);
   var fn = new Fn(this.model, name, path, inputPaths, fns, options);
   this.fromMap[path] = fn;
-  return fn.onInput();
+  return fn._onInput();
 };
 
 Fns.prototype.stop = function(path) {

--- a/test/Model/fn.js
+++ b/test/Model/fn.js
@@ -166,6 +166,29 @@ describe('fn', function() {
         done();
       });
     });
+    it('debouncing gets reset', function(done) {
+      var model = new Model();
+      model.fn('sum', function(a, b) {
+        return a + b;
+      });
+      model.set('_nums.a', 2);
+      model.set('_nums.b', 4);
+      model.start('_nums.sum', '_nums.a', '_nums.b', {async: true}, 'sum');
+      expect(model.get('_nums.sum')).to.equal(6);
+      model.set('_nums.a', 5);
+      // Synchronously, there should be no change
+      expect(model.get('_nums.sum')).to.equal(6);
+      // Async, the value should be updated
+      process.nextTick(function() {
+        expect(model.get('_nums.sum')).to.equal(9);
+        model.set('_nums.b', 0);
+        expect(model.get('_nums.sum')).to.equal(9);
+        process.nextTick(function() {
+          expect(model.get('_nums.sum')).to.equal(5);
+          done();
+        });
+      });
+    });
     it('no async sets the output multiple times when an input changes multiple times', function() {
       var model = new Model();
       var calls = 0;

--- a/test/Model/fn.js
+++ b/test/Model/fn.js
@@ -136,6 +136,86 @@ describe('fn', function() {
       expect(model.get('_nums.sum')).to.equal(5);
     });
   });
+  describe('start with async option', function() {
+    it('sets the output immediately on start', function() {
+      var model = new Model();
+      model.fn('sum', function(a, b) {
+        return a + b;
+      });
+      model.set('_nums.a', 2);
+      model.set('_nums.b', 4);
+      var value = model.start('_nums.sum', '_nums.a', '_nums.b', {async: true}, 'sum');
+      expect(value).to.equal(6);
+      expect(model.get('_nums.sum')).to.equal(6);
+    });
+    it('async sets the output when an input changes', function(done) {
+      var model = new Model();
+      model.fn('sum', function(a, b) {
+        return a + b;
+      });
+      model.set('_nums.a', 2);
+      model.set('_nums.b', 4);
+      model.start('_nums.sum', '_nums.a', '_nums.b', {async: true}, 'sum');
+      expect(model.get('_nums.sum')).to.equal(6);
+      model.set('_nums.a', 5);
+      // Synchronously, there should be no change
+      expect(model.get('_nums.sum')).to.equal(6);
+      // Async, the value should be updated
+      process.nextTick(function() {
+        expect(model.get('_nums.sum')).to.equal(9);
+        done();
+      });
+    });
+    it('no async sets the output multiple times when an input changes multiple times', function() {
+      var model = new Model();
+      var calls = 0;
+      model.fn('sum', function(a, b) {
+        calls++;
+        return a + b;
+      });
+      model.set('_nums.a', 2);
+      model.set('_nums.b', 4);
+      model.start('_nums.sum', '_nums.a', '_nums.b', 'sum');
+      expect(model.get('_nums.sum')).to.equal(6);
+      // Synchronously, the value should change
+      model.set('_nums.a', 1);
+      expect(model.get('_nums.sum')).to.equal(5);
+      model.set('_nums.a', 5);
+      expect(model.get('_nums.sum')).to.equal(9);
+      model.set('_nums.b', 10);
+      expect(model.get('_nums.sum')).to.equal(15);
+      model.set('_nums.b', 4);
+      expect(model.get('_nums.sum')).to.equal(9);
+      expect(calls).to.equal(5);
+    });
+    it('async sets the output when an input changes multiple times', function(done) {
+      var model = new Model();
+      var calls = 0;
+      model.fn('sum', function(a, b) {
+        calls++;
+        return a + b;
+      });
+      model.set('_nums.a', 2);
+      model.set('_nums.b', 4);
+      model.start('_nums.sum', '_nums.a', '_nums.b', {async: true}, 'sum');
+      expect(model.get('_nums.sum')).to.equal(6);
+      // Synchronously, there should be no change
+      model.set('_nums.a', 1);
+      expect(model.get('_nums.sum')).to.equal(6);
+      model.set('_nums.a', 5);
+      expect(model.get('_nums.sum')).to.equal(6);
+      model.set('_nums.b', 10);
+      expect(model.get('_nums.sum')).to.equal(6);
+      model.set('_nums.b', 4);
+      expect(model.get('_nums.sum')).to.equal(6);
+      // Async, the value should be updated once
+      process.nextTick(function() {
+        expect(model.get('_nums.sum')).to.equal(9);
+        expect(calls).to.equal(2);
+        done();
+      });
+    });
+  });
   describe('setter', function() {
     it('sets the input when the output changes', function() {
       var model = new Model();


### PR DESCRIPTION
Add option for explicit opt-in to running model.start async, and debounce changes to multiple inputs or multiple changes when performed synchronously. This avoids needless re-evaluations when the output is rendered in a UI and it is OK to do this async.