### PR TITLE
Do not garbage collect a doc if it has pending ops in Share

### DIFF
--- a/lib/Model/subscriptions.js
+++ b/lib/Model/subscriptions.js
@@ -172,6 +172,7 @@ Model.prototype._maybeUnloadDoc = function(collectionName, id) {
   if (!doc) return;
 
   if (this._hasDocReferences(collectionName, id)) return;
+  if (doc.shareDoc && doc.shareDoc.hasPending()) return;
 
   var previous = doc.get();
 


### PR DESCRIPTION
If Share is not going to garbage collect a doc yet because it has pending ops, Racer should not garbage collect it either. This prevents them from getting out of sync in highly specific scenarios.