### PR TITLE
Shallow clone refs value to avoid trying to access removed ref

### DIFF
--- a/lib/Model/ref.js
+++ b/lib/Model/ref.js
@@ -119,6 +119,10 @@ function addListener(model, type, fn) {
       // occured at that path
       var refs = toMap[subpath];
       if (!refs) continue;
+
+      // Shallow clone refs in case a ref is removed while going through
+      // the loop
+      refs = refs.slice();
       var remaining = segments.slice(i + 1);
       for (var refIndex = 0, numRefs = refs.length; refIndex < numRefs; refIndex++) {
         var ref = refs[refIndex];


### PR DESCRIPTION
When we have multiple listeners and one is removed before the other one is added, we run into an issue where the loop is trying to access an element of the `refs` array when it no longer exists.

Solution for the time being is to use a shallow clone of `refs`