### PR TITLE
add support for multiple arguments to model.scope() & model.at()

### DIFF
--- a/lib/Model/paths.js
+++ b/lib/Model/paths.js
@@ -28,9 +28,12 @@ Model.prototype.isPath = function(subpath) {
 };
 
 Model.prototype.scope = function(path) {
-  var model = this._child();
-  model._at = path;
-  return model;
+  if (arguments.length > 1) {
+    for (var i = 1; i < arguments.length; i++) {
+      path = path + '.' + arguments[i];
+    }
+  }
+  return createScoped(this, path);
 };
 
 /**
@@ -47,9 +50,20 @@ Model.prototype.scope = function(path) {
  *  @api public
  */
 Model.prototype.at = function(subpath) {
+  if (arguments.length > 1) {
+    for (var i = 1; i < arguments.length; i++) {
+      subpath = subpath + '.' + arguments[i];
+    }
+  }
   var path = this.path(subpath);
-  return this.scope(path);
+  return createScoped(this, path);
 };
+
+function createScoped(model, path) {
+  var scoped = model._child();
+  scoped._at = path;
+  return scoped;
+}
 
 /**
  * Returns a model scope that is a number of levels above the current scoped

--- a/test/Model/path.js
+++ b/test/Model/path.js
@@ -1,0 +1,63 @@
+var expect = require('../util').expect;
+var Model = require('../../lib/Model');
+
+describe('path methods', function() {
+  describe('path', function() {
+    it('returns empty string for model without scope', function() {
+      var model = new Model();
+      expect(model.path()).equal('');
+    });
+  });
+  describe('scope', function() {
+    it('returns a child model with the absolute scope', function() {
+      var model = new Model();
+      var scoped = model.scope('foo.bar.baz');
+      expect(model.path()).equal('');
+      expect(scoped.path()).equal('foo.bar.baz');
+    });
+    it('supports segments as separate arguments', function() {
+      var model = new Model();
+      var scoped = model.scope('foo', 'bar', 'baz');
+      expect(model.path()).equal('');
+      expect(scoped.path()).equal('foo.bar.baz');
+    });
+    it('overrides a previous scope', function() {
+      var model = new Model();
+      var scoped = model.scope('foo', 'bar', 'baz');
+      var scoped2 = scoped.scope('colors', 4);
+      expect(scoped2.path()).equal('colors.4');
+    });
+    it('supports no arguments', function() {
+      var model = new Model();
+      var scoped = model.scope('foo', 'bar', 'baz');
+      var scoped2 = scoped.scope();
+      expect(scoped2.path()).equal('');
+    });
+  });
+  describe('at', function() {
+    it('returns a child model with the relative scope', function() {
+      var model = new Model();
+      var scoped = model.at('foo.bar.baz');
+      expect(model.path()).equal('');
+      expect(scoped.path()).equal('foo.bar.baz');
+    });
+    it('supports segments as separate arguments', function() {
+      var model = new Model();
+      var scoped = model.at('foo', 'bar', 'baz');
+      expect(model.path()).equal('');
+      expect(scoped.path()).equal('foo.bar.baz');
+    });
+    it('overrides a previous scope', function() {
+      var model = new Model();
+      var scoped = model.at('colors');
+      var scoped2 = scoped.at(4);
+      expect(scoped2.path()).equal('colors.4');
+    });
+    it('supports no arguments', function() {
+      var model = new Model();
+      var scoped = model.at('foo', 'bar', 'baz');
+      var scoped2 = scoped.at();
+      expect(scoped2.path()).equal('foo.bar.baz');
+    });
+  });
+});


### PR DESCRIPTION
The arguments are effectively joined by dots. This will be helpful for adding typescript types to models while maintaining backwards compatibility.

Later, we probably want to maintain scope internally as an array rather than a string. Not solving that problem yet, but creating an array from multiple string arguments should be more efficient than splitting a string.

Alternative would be to accept array of strings as input, but that should probably be thought about across the board. Don't want to commit to it yet.