### PR TITLE
fix error where shareDoc.version can be null

### DIFF
--- a/lib/Model/bundle.js
+++ b/lib/Model/bundle.js
@@ -59,7 +59,7 @@ function serializeCollections(root) {
       var doc = collection.docs[id];
       var shareDoc = doc.shareDoc;
       var snapshot;
-      if (shareDoc) {
+      if (shareDoc && shareDoc.version !== null) {
         snapshot = {
           v: shareDoc.version,
           data: shareDoc.data

--- a/lib/Model/bundle.js
+++ b/lib/Model/bundle.js
@@ -59,13 +59,17 @@ function serializeCollections(root) {
       var doc = collection.docs[id];
       var shareDoc = doc.shareDoc;
       var snapshot;
-      if (shareDoc && shareDoc.version !== null) {
-        snapshot = {
-          v: shareDoc.version,
-          data: shareDoc.data
-        };
-        if (shareDoc.type !== defaultType) {
-          snapshot.type = doc.shareDoc.type && doc.shareDoc.type.name;
+      if (shareDoc) {
+        if (shareDoc.type == null && shareDoc.version == null) {
+          snapshot = undefined;
+        } else {
+          snapshot = {
+            v: shareDoc.version,
+            data: shareDoc.data
+          };
+          if (shareDoc.type !== defaultType) {
+            snapshot.type = doc.shareDoc.type && doc.shareDoc.type.name;
+          }
         }
       } else {
         snapshot = doc.data;

--- a/test/Model/bundle.js
+++ b/test/Model/bundle.js
@@ -1,0 +1,37 @@
+var expect = require('../util').expect;
+var racer = require('../../lib/index');
+
+describe('bundle', function() {
+  it('does not serialize Share docs with null versions', function(done) {
+    var backend = racer.createBackend();
+    var setupModel = backend.createModel();
+    setupModel.add('dogs', {id: 'coco', name: 'Coco'});
+    setupModel.whenNothingPending(function() {
+      var model1 = backend.createModel({fetchOnly: true});
+
+      // This creates a Share client Doc on the connection, with null version and data.
+      model1.connection.get('dogs', 'fido');
+      // Fetching a non-existent id results in a Share Doc with version 0 and undefined data.
+      model1.fetch('dogs.spot');
+      // This doc should be properly fetched and bundled.
+      model1.fetch('dogs.coco');
+
+      model1.whenNothingPending(function(err) {
+        if (err) return done(err);
+        model1.bundle(function(err, bundleData) {
+          if (err) return done(err);
+          // Simulate serialization of bundle data between server and client.
+          bundleData = JSON.parse(JSON.stringify(bundleData));
+
+          var model2 = backend.createModel();
+          model2.unbundle(bundleData);
+          expect(model2.get('dogs.fido')).to.equal(undefined);
+          expect(model2.get('dogs.spot')).to.equal(undefined);
+          expect(model2.get('dogs.coco')).to.eql({id: 'coco', name: 'Coco'});
+          done();
+        });
+      });
+    });
+  });
+});
+

--- a/test/Model/bundle.js
+++ b/test/Model/bundle.js
@@ -2,7 +2,7 @@ var expect = require('../util').expect;
 var racer = require('../../lib/index');
 
 describe('bundle', function() {
-  it('does not serialize Share docs with null versions', function(done) {
+  it('does not serialize Share docs with null versions and null type', function(done) {
     var backend = racer.createBackend();
     var setupModel = backend.createModel();
     setupModel.add('dogs', {id: 'coco', name: 'Coco'});


### PR DESCRIPTION
If shareDoc.version is null, then we can get a `ERR_INGESTED_SNAPSHOT_HAS_NO_VERSION` error