### PR TITLE
Prevent using saved query if new expression doesn't match hash

### DIFF
--- a/lib/Model/Query.js
+++ b/lib/Model/Query.js
@@ -137,7 +137,12 @@ Queries.prototype.remove = function(query) {
 };
 Queries.prototype.get = function(collectionName, expression, options) {
   var hash = queryHash(collectionName, expression, options);
-  return this.map[hash];
+  if (!this.map[hash]) return;
+  // Prevent getting saved query if expressions don't match
+  var existingExpression = this.map[hash]['expression'];
+  if (util.deepEqual(expression, existingExpression)) {
+    return this.map[hash];
+  }
 };
 Queries.prototype.toJSON = function() {
   var out = [];

--- a/lib/Model/Query.js
+++ b/lib/Model/Query.js
@@ -137,12 +137,7 @@ Queries.prototype.remove = function(query) {
 };
 Queries.prototype.get = function(collectionName, expression, options) {
   var hash = queryHash(collectionName, expression, options);
-  if (!this.map[hash]) return;
-  // Prevent getting saved query if expressions don't match
-  var existingExpression = this.map[hash]['expression'];
-  if (util.deepEqual(expression, existingExpression)) {
-    return this.map[hash];
-  }
+  return this.map[hash];
 };
 Queries.prototype.toJSON = function() {
   var out = [];
@@ -158,7 +153,7 @@ Queries.prototype.toJSON = function() {
 function Query(model, collectionName, expression, options) {
   this.model = model.pass({$query: this});
   this.collectionName = collectionName;
-  this.expression = expression;
+  this.expression = util.deepCopy(expression);
   this.options = options;
   this.hash = queryHash(collectionName, expression, options);
   this.segments = ['$queries', this.hash];

--- a/test/Model/query.js
+++ b/test/Model/query.js
@@ -16,6 +16,23 @@ describe('query', function() {
     });
   });
 
+  describe('Queries', function() {
+    beforeEach('create in-memory backend and model', function() {
+      this.backend = racer.createBackend();
+      this.model = this.backend.createModel();
+    });
+    it("creates new query if expression doesn't match saved expression", function() {
+      var query = this.model.query('myCollection', {arrayKey: []});
+      query.fetch();
+      // push value directly to query expression
+      query.expression.arrayKey.push('foo')
+      // Ensure query with same hash as original query uses expected expression
+      var newQuery = this.model.query('myCollection', {arrayKey: []});
+      newQuery.fetch();
+      expect(newQuery.expression.arrayKey).to.have.length(0);
+    })
+  });
+
   describe('idMap', function() {
     beforeEach('create in-memory backend and model', function() {
       this.backend = racer.createBackend();

--- a/test/Model/query.js
+++ b/test/Model/query.js
@@ -21,13 +21,13 @@ describe('query', function() {
       this.backend = racer.createBackend();
       this.model = this.backend.createModel();
     });
-    it("Uses deep copy of query expression in Query constructor", function() {
+    it('Uses deep copy of query expression in Query constructor', function() {
       var expression = {arrayKey: []};
       var query = this.model.query('myCollection', expression);
       query.fetch();
-      expression.arrayKey.push('foo')
+      expression.arrayKey.push('foo');
       expect(query.expression.arrayKey).to.have.length(0);
-    })
+    });
   });
 
   describe('idMap', function() {

--- a/test/Model/query.js
+++ b/test/Model/query.js
@@ -16,20 +16,17 @@ describe('query', function() {
     });
   });
 
-  describe('Queries', function() {
+  describe('Query', function() {
     beforeEach('create in-memory backend and model', function() {
       this.backend = racer.createBackend();
       this.model = this.backend.createModel();
     });
-    it("creates new query if expression doesn't match saved expression", function() {
-      var query = this.model.query('myCollection', {arrayKey: []});
+    it("Uses deep copy of query expression in Query constructor", function() {
+      var expression = {arrayKey: []};
+      var query = this.model.query('myCollection', expression);
       query.fetch();
-      // push value directly to query expression
-      query.expression.arrayKey.push('foo')
-      // Ensure query with same hash as original query uses expected expression
-      var newQuery = this.model.query('myCollection', {arrayKey: []});
-      newQuery.fetch();
-      expect(newQuery.expression.arrayKey).to.have.length(0);
+      expression.arrayKey.push('foo')
+      expect(query.expression.arrayKey).to.have.length(0);
     })
   });
 


### PR DESCRIPTION
Use deep copy of expression in Query constructor to prevent unintentional edits.