### PR TITLE
Added async verions of most Model and Query methods

### DIFF
--- a/lib/Model/async.js
+++ b/lib/Model/async.js
@@ -1,0 +1,132 @@
+var Model = require('./Model');
+var Query = require('./Query');
+
+/*
+ * Just return Promise which rejected on cb-error and resolved with function return
+ */
+function promisify(func, argumentsObject) {
+  var args = Array.prototype.slice.call(argumentsObject);
+  var self = this;
+
+  return new Promise(function(resolve, reject) {
+    var result;
+    args.push(function(err) {
+      if (err) reject(err);
+      else resolve(result);
+    });
+
+    result = func.apply(self, args);
+  });
+}
+
+// For model
+
+Model.prototype.fetchAsync = function() {
+  return promisify(this.fetch.bind(this), arguments);
+};
+
+Model.prototype.unfetchAsync = function() {
+  return promisify(this.unfetch.bind(this), arguments);
+};
+
+Model.prototype.subscribeAsync = function() {
+  return promisify(this.subscribe.bind(this), arguments);
+};
+
+Model.prototype.unsubscribeAsync = function() {
+  return promisify(this.unsubscribe.bind(this), arguments);
+};
+
+Model.prototype.setAsync = function() {
+  return promisify(this.set.bind(this), arguments);
+};
+
+Model.prototype.setDiffAsync = function() {
+  return promisify(this.setDiff.bind(this), arguments);
+};
+
+Model.prototype.setDiffDeepAsync = function() {
+  return promisify(this.setDiffDeep.bind(this), arguments);
+};
+
+Model.prototype.setNullAsync = function() {
+  return promisify(this.setNull.bind(this), arguments);
+};
+
+Model.prototype.setEachAsync = function() {
+  return promisify(this.setEach.bind(this), arguments);
+};
+
+Model.prototype.createAsync = function() {
+  return promisify(this.create.bind(this), arguments);
+};
+
+Model.prototype.createNullAsync = function() {
+  return promisify(this.createNull.bind(this), arguments);
+};
+
+Model.prototype.addAsync = function() {
+  return promisify(this.add.bind(this), arguments);
+};
+
+Model.prototype.delAsync = function() {
+  return promisify(this.del.bind(this), arguments);
+};
+
+Model.prototype.incrementAsync = function() {
+  return promisify(this.increment.bind(this), arguments);
+};
+
+Model.prototype.pushAsync = function() {
+  return promisify(this.push.bind(this), arguments);
+};
+
+Model.prototype.unshiftAsync = function() {
+  return promisify(this.unshift.bind(this), arguments);
+};
+
+Model.prototype.insertAsync = function() {
+  return promisify(this.insert.bind(this), arguments);
+};
+
+Model.prototype.popAsync = function() {
+  return promisify(this.pop.bind(this), arguments);
+};
+
+Model.prototype.shiftAsync = function() {
+  return promisify(this.shift.bind(this), arguments);
+};
+
+Model.prototype.removeAsync = function() {
+  return promisify(this.remove.bind(this), arguments);
+};
+
+Model.prototype.moveAsync = function() {
+  return promisify(this.move.bind(this), arguments);
+};
+
+Model.prototype.stringInsertAsync = function() {
+  return promisify(this.stringInsert.bind(this), arguments);
+};
+
+Model.prototype.stringRemoveAsync = function() {
+  return promisify(this.stringRemove.bind(this), arguments);
+};
+
+// For queries
+
+Query.prototype.fetchAsync = function() {
+  return promisify(this.fetch.bind(this), arguments);
+};
+
+Query.prototype.unfetchAsync = function() {
+  return promisify(this.unfetch.bind(this), arguments);
+};
+
+Query.prototype.subscribeAsync = function() {
+  return promisify(this.subscribe.bind(this), arguments);
+};
+
+Query.prototype.unsubscribeAsync = function() {
+  return promisify(this.unsubscribe.bind(this), arguments);
+};

--- a/lib/Model/index.js
+++ b/lib/Model/index.js
@@ -11,6 +11,7 @@ require('./setDiff');
 
 require('./connection');
 require('./subscriptions');
+require('./async');
 require('./Query');
 require('./contexts');
 

--- a/test/Model/async.js
+++ b/test/Model/async.js
@@ -1,0 +1,148 @@
+var expect = require('../util').expect;
+var racer = require('../../lib/index');
+
+describe('async', function() {
+  describe('fetchAsync', function() {
+    it('works', function(done) {
+      var backend = racer.createBackend();
+      var setupModel = backend.createModel();
+      setupModel.add('dogs', {id: 'coco', name: 'Coco'});
+      setupModel.whenNothingPending(function() {
+        var model1 = backend.createModel({fetchOnly: true});
+        var promise = model1.fetchAsync('dogs.coco');
+
+        expect(promise).assert(promise instanceof Promise);
+        promise.then(function() {
+          expect(model1.get('dogs.coco')).to.eql({id: 'coco', name: 'Coco'});
+          done();
+        });
+      });
+    });
+  });
+
+  describe('unfetchAsync', function() {
+    it('works', function(done) {
+      var backend = racer.createBackend();
+      var setupModel = backend.createModel();
+      setupModel.add('dogs', {id: 'coco', name: 'Coco'});
+      setupModel.whenNothingPending(function() {
+        var model1 = backend.createModel({fetchOnly: true});
+
+        model1.fetchAsync('dogs.coco').then(function() {
+          expect(model1.get('dogs.coco')).to.eql({id: 'coco', name: 'Coco'});
+
+          model1.unfetchAsync('dogs.coco').then(function() {
+            expect(model1.get('dogs.coco')).to.eql(undefined);
+            done();
+          });
+        });
+      });
+    });
+  });
+
+  describe('subscribeAsync', function() {
+    it('works', function(done) {
+      var backend = racer.createBackend();
+      var setupModel = backend.createModel();
+      setupModel.add('dogs', {id: 'coco', name: 'Coco'});
+      setupModel.whenNothingPending(function() {
+        var model1 = backend.createModel({fetchOnly: true});
+        var promise = model1.subscribeAsync('dogs.coco');
+
+        expect(promise).assert(promise instanceof Promise);
+        promise.then(function() {
+          expect(model1.get('dogs.coco')).to.eql({id: 'coco', name: 'Coco'});
+          done();
+        });
+      });
+    });
+  });
+
+  describe('unsubscribeAsync', function() {
+    it('works', function(done) {
+      var backend = racer.createBackend();
+      var setupModel = backend.createModel();
+      setupModel.add('dogs', {id: 'coco', name: 'Coco'});
+      setupModel.whenNothingPending(function() {
+        var model1 = backend.createModel({fetchOnly: true});
+
+        model1.subscribeAsync('dogs.coco').then(function() {
+          expect(model1.get('dogs.coco')).to.eql({id: 'coco', name: 'Coco'});
+
+          model1.unsubscribeAsync('dogs.coco').then(function() {
+            expect(model1.get('dogs.coco')).to.eql(undefined);
+            done();
+          });
+        });
+      });
+    });
+  });
+
+  describe('setAsync', function() {
+    it('works', function(done) {
+      var backend = racer.createBackend();
+      var setupModel = backend.createModel();
+      setupModel.add('dogs', {id: 'coco', name: 'Coco'});
+      setupModel.whenNothingPending(function() {
+        var model1 = backend.createModel({fetchOnly: true});
+
+        model1.fetchAsync('dogs.coco').then(function() {
+          model1.setAsync('dogs.coco.name', 'Soso').then(function(prevName) {
+            expect(prevName).to.eql('Coco');
+            expect(model1.get('dogs.coco')).to.eql({id: 'coco', name: 'Soso'});
+            done();
+          });
+        });
+      });
+    });
+  });
+
+  describe('setDiffAsync', function() {
+    it('works', function(done) {
+      var backend = racer.createBackend();
+      var setupModel = backend.createModel();
+      setupModel.add('dogs', {id: 'coco', name: 'Coco'});
+      setupModel.whenNothingPending(function() {
+        var model1 = backend.createModel({fetchOnly: true});
+
+        model1.fetchAsync('dogs.coco').then(function() {
+          model1.setDiffAsync('dogs.coco.name', 'Soso').then(function(prevName) {
+            expect(prevName).to.eql('Coco');
+            expect(model1.get('dogs.coco')).to.eql({id: 'coco', name: 'Soso'});
+            done();
+          });
+        });
+      });
+    });
+  });
+
+  describe('Queries', function() {
+    it('fetchAsync works', function(done) {
+      var backend = racer.createBackend();
+      var setupModel = backend.createModel();
+      setupModel.add('dogs', {id: 'coco', name: 'Coco'});
+      setupModel.whenNothingPending(function() {
+        var model1 = backend.createModel({fetchOnly: true});
+        var query = model1.query('dogs', {name: 'Coco'});
+        query.fetchAsync().then(function() {
+          expect(query.get()[0]).to.eql({id: 'coco', name: 'Coco'});
+          done();
+        });
+      });
+    });
+
+    it('subscribeAsync works', function(done) {
+      var backend = racer.createBackend();
+      var setupModel = backend.createModel();
+      setupModel.add('dogs', {id: 'coco', name: 'Coco'});
+      setupModel.whenNothingPending(function() {
+        var model1 = backend.createModel({fetchOnly: true});
+        var query = model1.query('dogs', {name: 'Coco'});
+        query.subscribeAsync().then(function() {
+          expect(query.get()[0]).to.eql({id: 'coco', name: 'Coco'});
+          done();
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
Hi. I added async versions (it returns Promise) of most methods of Model and Query. And created some tests for it.

If method returns some value it will be passed to resolve()
All methods has name {original}Async.
So, now you can write code with async/await

What do you think about moveing to promise-based racer?