### PR TITLE
Fix reference to this in _maybeUnloadDoc inner function

### DIFF
--- a/lib/Model/subscriptions.js
+++ b/lib/Model/subscriptions.js
@@ -194,7 +194,7 @@ Model.prototype._maybeUnloadDoc = function(collectionName, id) {
     // Remove doc from Share
     if (doc.shareDoc) doc.shareDoc.destroy();
 
-    model.emit('unload', [collectionName, id], [previous, this._pass]);
+    model.emit('unload', [collectionName, id], [previous, model._pass]);
   }
 };
 


### PR DESCRIPTION
The inner function was introduced in introduced in a320772 (PR https://github.com/derbyjs/racer/pull/276).

I missed changing a `this` to `model`.

I'll look into adding a test later, I want to get this fix out quickly.

----

This can cause an error like `TypeError: Cannot read property '$remote' of undefined` in listeners that are checking properties the `pass` object.

Stack trace will have a snippet like this:

```
  at Model.emit [as _emit] (events.js:203:15)
  at Model.emit (.../node_modules/racer/lib/Model/events.js:99:10)
  at unloadDoc (.../node_modules/racer/lib/Model/subscriptions.js:197:11)
  at Model._maybeUnloadDoc (.../node_modules/racer/lib/Model/subscriptions.js:186:5)
  at finishUnfetchDoc (.../node_modules/racer/lib/Model/subscriptions.js:127:11)
  at Model.unfetchDoc (.../node_modules/racer/lib/Model/subscriptions.js:122:5)
  at Model._forSubscribable (.../node_modules/racer/lib/Model/subscriptions.js:66:24)
  at Model.unfetch (.../node_modules/racer/lib/Model/subscriptions.js:21:8)
```