### PR TITLE
Be more defensive for delayed doc unload introduced in a320772a

### DIFF
--- a/lib/Model/subscriptions.js
+++ b/lib/Model/subscriptions.js
@@ -190,7 +190,7 @@ Model.prototype._maybeUnloadDoc = function(collectionName, id) {
     var previous = doc.get();
 
     // Remove doc from Racer
-    model.root.collections[collectionName].remove(id);
+    if (model.root.collections[collectionName]) model.root.collections[collectionName].remove(id);
     // Remove doc from Share
     if (doc.shareDoc) doc.shareDoc.destroy();
 


### PR DESCRIPTION
In https://github.com/derbyjs/racer/pull/276, I introduced deferred doc unload to fix a memory leak introduced by a PR last year.

However, if a doc gets two unloads deferred, the second one can fail with a stack trace like this:

```
     Uncaught TypeError: Cannot read property 'remove' of undefined
      at Doc.unloadDoc (node_modules/racer/lib/Model/subscriptions.js:193:44)
      at Doc._emitNothingPending (node_modules/sharedb/lib/client/doc.js:246:8)
      at Doc._clearInflightOp (node_modules/sharedb/lib/client/doc.js:962:8)
      at Doc._opAcknowledged (node_modules/sharedb/lib/client/doc.js:884:8)
      at Doc._handleOp (node_modules/sharedb/lib/client/doc.js:315:10)
      at Connection.handleMessage (node_modules/sharedb/lib/client/connection.js:246:20)
      at StreamSocket.socket.onmessage (node_modules/sharedb/lib/client/connection.js:139:18)
```

This fixes the double deferred unload case by being more defensive.