### PR TITLE
Fix deferred unload (see a320772a) when unfetching then synchronously subscribing

### DIFF
--- a/lib/Model/subscriptions.js
+++ b/lib/Model/subscriptions.js
@@ -181,12 +181,13 @@ Model.prototype._maybeUnloadDoc = function(collectionName, id) {
   // ShareDB, we can end up with an inconsistent state, with the data existing
   // in ShareDB not reflected in the racer model data
   if (doc.shareDoc && doc.shareDoc.hasPending()) {
-    doc.shareDoc.whenNothingPending(unloadDoc);
+    // If the Share doc still has pending activity, retry _maybeUnloadDoc once
+    // the pending activity is done.
+    doc.shareDoc.whenNothingPending(function() {
+      model._maybeUnloadDoc(collectionName, id);
+    });
   } else {
-    unloadDoc();
-  }
-
-  function unloadDoc() {
+    // Otherwise, actually do the unload.
     var previous = doc.get();
 
     // Remove doc from Racer

--- a/test/Model/loading.js
+++ b/test/Model/loading.js
@@ -46,28 +46,56 @@ describe('loading', function() {
     });
   });
 
-  describe('unfetch', function() {
-    it('unloads doc after Share doc has nothing pending', function(done) {
-      var setupModel = this.backend.createModel();
-      var model = this.model;
-      setupModel.add('colors', {id: 'green', hex: '00ff00'}, function(err) {
-        if (err) return done(err);
+  describe('unfetch deferred unload', function() {
+    beforeEach(function(done) {
+      this.setupModel = this.backend.createModel();
+      this.setupModel.add('colors', {id: 'green', hex: '00ff00'}, done);
+    });
 
-        model.fetch('colors.green', function(err) {
-          if (err) return done(err);
-          expect(model.get('colors.green.hex')).to.equal('00ff00');
-          // Queue up a pending op.
-          model.set('colors.green.hex', '00ee00');
-          // Unfetch. The pending op prevents the doc from immedialy being unloaded.
-          model.unfetch('colors.green');
-          // Once there's nothing pending on the model/doc...
-          model.whenNothingPending(function() {
-            // Racer doc should be unloaded.
-            expect(model.get('colors.green')).to.equal(undefined);
-            // Share doc should be unloaded too.
-            expect(model.connection.getExisting('colors', 'green')).to.equal(undefined);
-            done();
-          });
+    it('unloads doc after Share doc has nothing pending', function(done) {
+      var model = this.model;
+      model.fetch('colors.green', function(err) {
+        if (err) return done(err);
+        expect(model.get('colors.green.hex')).to.equal('00ff00');
+        // Queue up a pending op.
+        model.set('colors.green.hex', '00ee00');
+        // Unfetch. This triggers the delayed _maybeUnloadDoc.
+        // The pending op causes the doc unload to be delayed.
+        model.unfetch('colors.green');
+        // Once there's nothing pending on the model/doc...
+        model.whenNothingPending(function() {
+          // Racer doc should be unloaded.
+          expect(model.get('colors.green')).to.equal(undefined);
+          // Share doc should be unloaded too.
+          expect(model.connection.getExisting('colors', 'green')).to.equal(undefined);
+          done();
+        });
+      });
+    });
+
+    it('does not unload doc if a subscribe is issued in the meantime', function(done) {
+      var model = this.model;
+      // Racer keeps its own reference counts of doc fetches/subscribes - see `_hasDocReferences`.
+      model.fetch('colors.green', function(err) {
+        if (err) return done(err);
+        expect(model.get('colors.green.hex')).to.equal('00ff00');
+        // Queue up a pending op.
+        model.set('colors.green.hex', '00ee00');
+        // Unfetch. This triggers the delayed _maybeUnloadDoc.
+        // The pending op causes the doc unload to be delayed.
+        model.unfetch('colors.green');
+        // Immediately subscribe to the same doc.
+        // This causes the doc to be kept in memory, even after the unfetch completes.
+        model.subscribe('colors.green');
+        // Once there's nothing pending on the model/doc...
+        model.whenNothingPending(function() {
+          // Racer doc should still be present due to the subscription.
+          expect(model.get('colors.green')).to.eql({id: 'green', hex: '00ee00'});
+          // Share doc should be present too.
+          var shareDoc = model.connection.getExisting('colors', 'green');
+          expect(shareDoc).to.have.property('data');
+          expect(shareDoc.data).to.eql({id: 'green', hex: '00ee00'});
+          done();
         });
       });
     });


### PR DESCRIPTION
When a doc gets unfetched, https://github.com/derbyjs/racer/pull/276 adds a Share Doc `whenNothingPending` listener to unload the doc later, instead of doing nothing, which was the cause of a memory leak introduced in https://github.com/derbyjs/racer/pull/266.

However, Racer keeps reference counts itself for fetches and subscriptions, so an immediate subscribe on the same Racer doc does not affect the Share doc at all, which means the doc would still get unloaded, erroneously.

This fix instead retries the Racer `_maybeUnloadDoc` in that scenario, instead of doing an immediate unload. That guards against Racer getting new doc references while the Share Doc `whenNotingPending` is in progress.

----

For reference, the new test for the scenario fails like this without the subscriptions.js change:

```
  1) loading
       unfetch deferred unload
         does not unload doc if a subscribe is issued in the meantime:
     Uncaught Error: expected undefined to sort of equal { id: 'green', hex: '00ee00' }
      at Assertion.assert (node_modules/expect.js/index.js:96:13)
      at Assertion.eql (node_modules/expect.js/index.js:230:10)
      at .../derbyjs/racer/test/Model/loading.js:93:48
      at process._tickCallback (internal/process/next_tick.js:61:11)
```