### PR TITLE
Add additional signature for Model#filter that doesn't use var-args

### DIFF
--- a/lib/Model/filter.js
+++ b/lib/Model/filter.js
@@ -23,18 +23,29 @@ Model.INITS.push(function(model) {
 
 function parseFilterArguments(model, args) {
   var fn = args.pop();
-  var options;
-  if (!model.isPath(args[args.length - 1])) {
+  var options, inputPaths;
+  var path = model.path(args.shift());
+
+  var last = args[args.length - 1];
+  if (!model.isPath(last) && !Array.isArray(last)) {
     options = args.pop();
   }
-  var path = model.path(args.shift());
-  var i = args.length;
+  if (args.length === 1 && Array.isArray(args[0])) {
+    // inputPaths provided as one array:
+    //   model.filter(inputPath, [inputPath1, inputPath2], fn)
+    inputPaths = args[0];
+  } else {
+    // inputPaths provided as var-args:
+    //   model.filter(inputPath, inputPath1, inputPath2, fn)
+    inputPaths = args;
+  }
+  var i = inputPaths.length;
   while (i--) {
-    args[i] = model.path(args[i]);
+    inputPaths[i] = model.path(inputPaths[i]);
   }
   return {
     path: path,
-    inputPaths: (args.length) ? args : null,
+    inputPaths: inputPaths,
     options: options,
     fn: fn
   };

--- a/lib/Model/filter.js
+++ b/lib/Model/filter.js
@@ -45,7 +45,7 @@ function parseFilterArguments(model, args) {
   }
   return {
     path: path,
-    inputPaths: inputPaths,
+    inputPaths: (inputPaths.length) ? inputPaths : null,
     options: options,
     fn: fn
   };

--- a/test/Model/filter.js
+++ b/test/Model/filter.js
@@ -47,6 +47,46 @@ describe('filter', function() {
       var filter = model.filter('numbers', 'even').sort();
       expect(filter.get()).to.eql([0, 0, 2, 4]);
     });
+    it('supports additional input paths as var-args', function() {
+      var model = (new Model()).at('_page');
+      var numbers = [0, 3, 4, 1, 2, 3, 0];
+      for (var i = 0; i < numbers.length; i++) {
+        model.set('numbers.' + model.id(), numbers[i]);
+      }
+      model.set('mod', 3);
+      model.set('offset', 0);
+      var filter = model.filter('numbers', 'mod', 'offset', function(number, id, numbers, mod, offset) {
+        return (number % mod) === offset;
+      });
+      expect(filter.get()).to.eql([0, 3, 3, 0]);
+    });
+    it('supports additional input paths as array', function() {
+      var model = (new Model()).at('_page');
+      var numbers = [0, 3, 4, 1, 2, 3, 0];
+      for (var i = 0; i < numbers.length; i++) {
+        model.set('numbers.' + model.id(), numbers[i]);
+      }
+      model.set('mod', 3);
+      model.set('offset', 0);
+      var filter = model.filter('numbers', ['mod', 'offset'], function(number, id, numbers, mod, offset) {
+        return (number % mod) === offset;
+      });
+      expect(filter.get()).to.eql([0, 3, 3, 0]);
+    });
+    it('supports a skip option', function() {
+      var model = (new Model()).at('_page');
+      var numbers = [0, 3, 4, 1, 2, 3, 0];
+      var options = {skip: 2};
+      for (var i = 0; i < numbers.length; i++) {
+        model.set('numbers.' + model.id(), numbers[i]);
+      }
+      model.set('mod', 3);
+      model.set('offset', 0);
+      var filter = model.filter('numbers', ['mod', 'offset'], options, function(number, id, numbers, mod, offset) {
+        return (number % mod) === offset;
+      });
+      expect(filter.get()).to.eql([3, 0]);
+    });
   });
   describe('initial value set by ref', function() {
     it('supports filter of object', function() {
@@ -141,7 +181,7 @@ describe('filter', function() {
         }
       ]);
     });
-    it('supports additional dynamic inputs', function() {
+    it('supports additional dynamic inputs as var-args', function() {
       var model = (new Model()).at('_page');
       var numbers = [0, 3, 4, 1, 2, 3, 0];
       for (var i = 0; i < numbers.length; i++) {
@@ -150,6 +190,23 @@ describe('filter', function() {
       model.set('mod', 3);
       model.set('offset', 0);
       var filter = model.filter('numbers', 'mod', 'offset', function(number, id, numbers, mod, offset) {
+        return (number % mod) === offset;
+      });
+      expect(filter.get()).to.eql([0, 3, 3, 0]);
+      model.set('offset', 1);
+      expect(filter.get()).to.eql([4, 1]);
+      model.set('mod', 2);
+      expect(filter.get()).to.eql([3, 1, 3]);
+    });
+    it('supports additional dynamic inputs as array', function() {
+      var model = (new Model()).at('_page');
+      var numbers = [0, 3, 4, 1, 2, 3, 0];
+      for (var i = 0; i < numbers.length; i++) {
+        model.set('numbers.' + model.id(), numbers[i]);
+      }
+      model.set('mod', 3);
+      model.set('offset', 0);
+      var filter = model.filter('numbers', ['mod', 'offset'], function(number, id, numbers, mod, offset) {
         return (number % mod) === offset;
       });
       expect(filter.get()).to.eql([0, 3, 3, 0]);


### PR DESCRIPTION
The var-args for additionalInputPaths in Model#filter make it difficult to write TypeScript type definitions.

These backwards-compatible changes add alternative signatures to allow array of `additionalInputPaths`.
```javascript
model.filter(inPath1, inPath2, inPath3, ..., fn);  // Old
model.filter(inPath1, [inPath2, inPath3, ...], fn); // New
```