### PR TITLE
Set path when useEventObjects: true

### DIFF
--- a/lib/Model/events.js
+++ b/lib/Model/events.js
@@ -326,6 +326,7 @@ function getMutationListener(model, type, arg1, arg2, arg3) {
     pattern = model.path(arg1);
     if (pattern == null) {
       options = arg1;
+      pattern = model.path();
     }
     cb = arg2;
   } else if (typeof arg1 === 'function') {
@@ -342,12 +343,7 @@ function getMutationListener(model, type, arg1, arg2, arg3) {
     throw new Error('No expected callback function');
   }
   if (!pattern) {
-    if (options && options.useEventObjects) {
-      return createMutationListener(model.path('**'), model._eventContext, cb);
-    } else {
-      // Listen to raw event emission when no path is provided
-      return new MutationListener(['**'], model._eventContext, cb);
-    }
+    return new MutationListener(['**'], model._eventContext, cb);
   }
   pattern = normalizePattern(pattern);
   return (options && options.useEventObjects) ?

--- a/lib/Model/events.js
+++ b/lib/Model/events.js
@@ -340,10 +340,10 @@ function getMutationListener(model, type, arg1, arg2, arg3) {
     pattern = model.path();
     cb = arg1;
   } else {
-    // Listen to raw event emission when no path is provided
     throw new Error('No expected callback function');
   }
   if (!pattern) {
+    // Listen to raw event emission when no path is provided
     return new MutationListener(['**'], model._eventContext, cb);
   }
   pattern = normalizePattern(pattern);

--- a/lib/Model/events.js
+++ b/lib/Model/events.js
@@ -340,6 +340,7 @@ function getMutationListener(model, type, arg1, arg2, arg3) {
     pattern = model.path();
     cb = arg1;
   } else {
+    // Listen to raw event emission when no path is provided
     throw new Error('No expected callback function');
   }
   if (!pattern) {

--- a/lib/Model/events.js
+++ b/lib/Model/events.js
@@ -106,7 +106,8 @@ Model.prototype._emitMutation = function(segments, event) {
       throw new Error(
         'Maximum model mutation event cycles exceeded. Most likely, an event ' +
         'listener is performing a mutation that emits an event to the same ' +
-        'listener, directly or indirectly. This creates an infinite cycle.'
+        'listener, directly or indirectly. This creates an infinite cycle. Queue details: \n' +
+        JSON.stringify(root._mutationEventQueue, null, 2)
       );
     }
     var queue = root._mutationEventQueue;
@@ -341,8 +342,12 @@ function getMutationListener(model, type, arg1, arg2, arg3) {
     throw new Error('No expected callback function');
   }
   if (!pattern) {
-    // Listen to raw event emission when no path is provided
-    return new MutationListener(['**'], model._eventContext, cb);
+    if (options && options.useEventObjects) {
+      return createMutationListener(model.path('**'), model._eventContext, cb);
+    } else {
+      // Listen to raw event emission when no path is provided
+      return new MutationListener(['**'], model._eventContext, cb);
+    }
   }
   pattern = normalizePattern(pattern);
   return (options && options.useEventObjects) ?

--- a/test/Model/events.js
+++ b/test/Model/events.js
@@ -143,6 +143,7 @@ describe('Model events with {useEventObjects: true}', function() {
       });
       model.set('a', 1);
     });
+
     it('calls later listeners in the order of mutations', function(done) {
       var model = (new racer.Model()).at('_page');
       model.on('change', 'a', function() {
@@ -157,6 +158,15 @@ describe('Model events with {useEventObjects: true}', function() {
         if (!expectedPaths.length) {
           done();
         }
+      });
+      model.set('a', 1);
+    });
+
+    it('can omit the path argument when useEventObjects is true', function(done) {
+      var model = (new racer.Model()).at('_page');
+      model.on('change', {useEventObjects: true}, function(_event, captures) {
+        expect(captures).to.eql('a');
+        done();
       });
       model.set('a', 1);
     });

--- a/test/Model/events.js
+++ b/test/Model/events.js
@@ -1,7 +1,7 @@
 var expect = require('../util').expect;
 var racer = require('../../lib/index');
 
-describe('Model events', function() {
+describe('Model events without useEventObjects', function() {
   describe('mutator events', function() {
     it('calls earlier listeners in the order of mutations', function(done) {
       var model = (new racer.Model()).at('_page');
@@ -20,6 +20,7 @@ describe('Model events', function() {
       });
       model.set('a', 1);
     });
+
     it('calls later listeners in the order of mutations', function(done) {
       var model = (new racer.Model()).at('_page');
       model.on('change', 'a', function() {
@@ -34,6 +35,17 @@ describe('Model events', function() {
         if (!expectedPaths.length) {
           done();
         }
+      });
+      model.set('a', 1);
+    });
+
+    it('can omit the path argument', function(done) {
+      var model = (new racer.Model()).at('_page');
+
+      model.at('a').on('change', function(value, prev) {
+        expect(value).to.equal(1);
+        expect(prev).to.be.empty;
+        done();
       });
       model.set('a', 1);
     });
@@ -164,8 +176,10 @@ describe('Model events with {useEventObjects: true}', function() {
 
     it('can omit the path argument when useEventObjects is true', function(done) {
       var model = (new racer.Model()).at('_page');
-      model.on('change', {useEventObjects: true}, function(_event, captures) {
-        expect(captures).to.eql('a');
+
+      model.at('a').on('change', {useEventObjects: true}, function(_event, captures) {
+        expect(_event.value).to.equal(1);
+        expect(captures).to.have.length(0);
         done();
       });
       model.set('a', 1);


### PR DESCRIPTION
This showed up while testing the `event-listener-tree` changes.

> NOTE: This PR is just to merge into the other branch, but I wanted to make it super visible for review purposes. 

It seems as if with the new changes, we no longer support using `useEventObjects: true` with no `path` provided as an argument. In the calling code I was testing, I was able to work around the issue by adding the `**` path argument. 

A failing test has been added here which passes with the new check I added. 

I'm not sure this is the cleanest solution. Not being very familiar with this code, I am open to suggestions! 