### PR TITLE
Provide the documented properties on Event objects for backwards compatibility

### DIFF
--- a/lib/Model/events.js
+++ b/lib/Model/events.js
@@ -482,7 +482,13 @@ InsertEvent.prototype._getArgs = function() {
 
 function RemoveEvent(index, values, passed) {
   this.index = index;
+
+  // Provide both a `values` and `removed` property
+  // `values` is more aligned with other events,
+  // but `removed` is needed for backwards compatibily
   this.values = values;
+  this.removed = values;
+
   this.passed = passed;
 }
 RemoveEvent.prototype.type = 'remove';

--- a/lib/Model/events.js
+++ b/lib/Model/events.js
@@ -442,6 +442,7 @@ ChangeEvent.prototype._getArgs = function() {
 
 function LoadEvent(value, passed) {
   this.value = value;
+  this.document = value;
   this.passed = passed;
 }
 LoadEvent.prototype.type = 'load';
@@ -455,6 +456,7 @@ LoadEvent.prototype._getArgs = function() {
 
 function UnloadEvent(previous, passed) {
   this.previous = previous;
+  this.previousDocument = previous;
   this.passed = passed;
 }
 UnloadEvent.prototype.type = 'unload';
@@ -482,13 +484,8 @@ InsertEvent.prototype._getArgs = function() {
 
 function RemoveEvent(index, values, passed) {
   this.index = index;
-
-  // Provide both a `values` and `removed` property
-  // `values` is more aligned with other events,
-  // but `removed` is needed for backwards compatibily
   this.values = values;
   this.removed = values;
-
   this.passed = passed;
 }
 RemoveEvent.prototype.type = 'remove';

--- a/test/Model/events.js
+++ b/test/Model/events.js
@@ -286,52 +286,63 @@ describe('Model events with {useEventObjects: true}', function() {
         this.remote.on('move', '**', {useEventObjects: true}, function(event) {
           expect(event.from).to.equal(4);
           expect(event.to).to.equal(0);
+          expect(event.howMany).to.equal(1);
           done();
         });
         this.local.move('array', 4, 0, 1);
       });
+
       it('can swap the first two items in the array', function(done) {
         this.local.set('array', [0, 1, 2, 3, 4], function() {});
         this.remote.on('move', '**', {useEventObjects: true}, function(event) {
           expect(event.from).to.equal(1);
           expect(event.to).to.equal(0);
+          expect(event.howMany).to.equal(1);
           done();
         });
         this.local.move('array', 1, 0, 1, function() {});
       });
+
       it('can move an item from the begnning to the end of the array', function(done) {
         this.local.set('array', [0, 1, 2, 3, 4], function() {});
         this.remote.on('move', '**', {useEventObjects: true}, function(event) {
           expect(event.from).to.equal(0);
           expect(event.to).to.equal(4);
+          expect(event.howMany).to.equal(1);
           done();
         });
         this.local.move('array', 0, 4, 1, function() {});
       });
+
       it('supports a negative destination index of -1 (for last)', function(done) {
         this.local.set('array', [0, 1, 2, 3, 4], function() {});
         this.remote.on('move', '**', {useEventObjects: true}, function(event) {
           expect(event.from).to.equal(0);
           expect(event.to).to.equal(4);
+          expect(event.howMany).to.equal(1);
           done();
         });
         this.local.move('array', 0, -1, 1, function() {});
       });
+
       it('supports a negative source index of -1 (for last)', function(done) {
         this.local.set('array', [0, 1, 2, 3, 4], function() {});
         this.remote.on('move', '**', {useEventObjects: true}, function(event) {
           expect(event.from).to.equal(4);
           expect(event.to).to.equal(2);
+          expect(event.howMany).to.equal(1);
           done();
         });
         this.local.move('array', -1, 2, 1, function() {});
       });
+
       it('can move several items mid-array, with an event for each', function(done) {
         this.local.set('array', [0, 1, 2, 3, 4], function() {});
         var events = 0;
         this.remote.on('move', '**', {useEventObjects: true}, function(event) {
           expect(event.from).to.equal(1);
           expect(event.to).to.equal(4);
+          expect(event.howMany).to.equal(1);
           if (++events === 2) {
             done();
           }

--- a/test/Model/events.js
+++ b/test/Model/events.js
@@ -184,6 +184,22 @@ describe('Model events with {useEventObjects: true}', function() {
       });
       model.set('a', 1);
     });
+
+    describe('remove', function() {
+      it('has removed property', function(done) {
+        var model = (new racer.Model()).at('_page');
+        model.set('a', [1, 2, 3]);
+        model.on('remove', '**', {useEventObjects: true}, function(_event, captures) {
+          expect(_event.type).to.equal('remove');
+          expect(_event.index).to.equal(2);
+          expect(_event.removed).to.eql([3]);
+          expect(_event.values).to.eql([3]);
+          expect(captures).to.eql(['a']);
+          done();
+        });
+        model.pop('a');
+      });
+    });
   });
 
   describe('remote events', function() {


### PR DESCRIPTION
According to our docs, we expect certain `Event` types to have custom properties e.g. the `removed` property on a `RemoveEvent`. However, we refactored to rely more heavily on the `value` property. This change adds back the old custom property names while still keeping the `value` available. Docs for reference: https://derbyjs.com/docs/derby-0.10/models/events