### PR TITLE
Support sharedb@2 alongside sharedb@1

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "arraydiff": "^0.1.1",
     "fast-deep-equal": "^2.0.1",
-    "sharedb": "^1.0.0-beta",
+    "sharedb": "^1.0.0 || ^2.0.0",
     "uuid": "^2.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
The only change in sharedb@2 is dropping support for Node 10, so racer can continue to support both versions of sharedb.

https://github.com/share/sharedb/releases/tag/v2.0.0