### PR TITLE
In Model#bundle, use new Contexts#toJSON method for consistency with other data bundle properties

### DIFF
--- a/lib/Model/bundle.js
+++ b/lib/Model/bundle.js
@@ -21,7 +21,7 @@ Model.prototype.bundle = function(cb) {
     clearTimeout(timeout);
     var bundle = {
       queries: root._queries.toJSON(),
-      contexts: root._contexts,
+      contexts: root._contexts.toJSON(),
       refs: root._refs.toJSON(),
       refLists: root._refLists.toJSON(),
       fns: root._fns.toJSON(),

--- a/lib/Model/contexts.js
+++ b/lib/Model/contexts.js
@@ -39,6 +39,16 @@ Model.prototype.unloadAll = function() {
 };
 
 function Contexts() {}
+Contexts.prototype.toJSON = function() {
+  var out = {};
+  var contexts = this;
+  for (var key in contexts) {
+    if (contexts[key] instanceof Context) {
+      out[key] = contexts[key].toJSON();
+    }
+  }
+  return out;
+};
 
 function FetchedQueries() {}
 function SubscribedQueries() {}


### PR DESCRIPTION
In `Model#bundle` today, all object property values except `contexts` go through a `toJSON()` to get a serializable form of the values.

For consistency, this changes `Model#bundle` to use a new `Contexts#toJSON` as well, for consistency. That just loops 
over each context and calls the existing `Context#toJSON` on each.

This doesn't change the final serialized JSON-string representation, as `JSON.stringify` automatically calls the contexts' `#toJSON` today. This just pushes those `#toJSON` calls a bit earlier.