### PR TITLE
Fix Contexts#unloadAll to account for addition of toJSON method

### DIFF
--- a/lib/Model/contexts.js
+++ b/lib/Model/contexts.js
@@ -34,7 +34,9 @@ Model.prototype.unload = function(id) {
 Model.prototype.unloadAll = function() {
   var contexts = this.root._contexts;
   for (var key in contexts) {
-    contexts[key].unload();
+    if (contexts.hasOwnProperty(key)) {
+      contexts[key].unload();
+    }
   }
 };
 


### PR DESCRIPTION
https://github.com/derbyjs/racer/pull/293 meant that the for..in `Contexts#unloadAll` would loop over the new `toJSON` method as well.

Add a `hasOwnProperty` guard to skip over the `toJSON` method and any future ones that may be added.