### PR TITLE
Strip ref outputs from initial data bundle, to reduce size

### DIFF
--- a/lib/Model/bundle.js
+++ b/lib/Model/bundle.js
@@ -41,6 +41,9 @@ function stripComputed(root) {
   root._refLists.fromMap.forEach(function(refList) {
     silentModel._del(refList.fromSegments);
   });
+  root._refs.fromMap.forEach(function(ref) {
+    silentModel._delNoDereference(ref.fromSegments);
+  });
   root._fns.fromMap.forEach(function(fn) {
     silentModel._del(fn.fromSegments);
   });

--- a/lib/Model/mutators.js
+++ b/lib/Model/mutators.js
@@ -266,6 +266,9 @@ Model.prototype.del = function() {
 };
 Model.prototype._del = function(segments, cb) {
   segments = this._dereference(segments);
+  return this._delNoDereference(segments, cb);
+};
+Model.prototype._delNoDereference = function(segments, cb) {
   var model = this;
   function del(doc, docSegments, fnCb) {
     var previous = doc.del(docSegments, fnCb);


### PR DESCRIPTION
## Background

On initial page load, the server model data gets serialized into a data bundle, to be sent to the client in the response HTML.

During this process, `stripComputed` removes the outputs of ref lists and reactive functions, to reduce bundle size by locally deleting duplicated data that can be easily reconstructed on the client.

As it turns out, normal refs' outputs weren't getting stripped. I presume it wasn't done because, for the current implementation of the cleanup, the deletion of a local ref pointing to a remote (DB-backed) doc would've caused the remote doc to get deleted.

## Changes

This PR adds the stripping of ref outputs in the initial data bundle, by using a new internal `_delNoDereference` that does a purely local delete, not following the ref. That avoids the problem of inadvertently deleting a remote doc during `stripComputed`.