### PR TITLE
Fix var reference error within Model.unload() and add regression tests.

### DIFF
--- a/lib/Model/contexts.js
+++ b/lib/Model/contexts.js
@@ -128,21 +128,21 @@ Context.prototype.unload = function() {
   }
   for (var collectionName in this.fetchedDocs.collections) {
     var collection = this.fetchedDocs.collections[collectionName];
-    for (var id in collection) {
+    for (var id in collection.counts) {
       var count = collection.counts[id];
       while (count--) model.unfetchDoc(collectionName, id);
     }
   }
   for (var collectionName in this.subscribedDocs.collections) {
     var collection = this.subscribedDocs.collections[collectionName];
-    for (var id in collection) {
+    for (var id in collection.counts) {
       var count = collection.counts[id];
       while (count--) model.unsubscribeDoc(collectionName, id);
     }
   }
   for (var collectionName in this.createdDocs.collections) {
     var collection = this.createdDocs.collections[collectionName];
-    for (var id in collection) {
+    for (var id in collection.counts) {
       model._maybeUnloadDoc(collectionName, id);
     }
   }


### PR DESCRIPTION
### Context
Previously, when calling `Model.unload()`, we were accidentally iterating over the properties of a CounterMap rather than iterating over the keys within the CounterMap.
### Changes
- Updates `Model.unload()` to correctly iterate over the keys within the CounterMap's count property and pass the resulting document IDs into unfetchDoc, unsubscribeDoc, and _maybeUnloadDoc.
- Adds regression tests to the associated loading.js cases.
### Proof of failing tests before patch
<img width="1001" alt="image" src="https://user-images.githubusercontent.com/1167801/206049108-21c958bf-e5be-43aa-9fdf-4cd0d9fa9c39.png">

