### PR TITLE
Support sharedb@3 in dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "arraydiff": "^0.1.1",
     "fast-deep-equal": "^2.0.1",
-    "sharedb": "^1.0.0 || ^2.0.0",
+    "sharedb": "^1.0.0 || ^2.0.0 || ^3.0.0",
     "uuid": "^2.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
The only breaking change in sharedb@3 is dropping official Node 12 support, so Racer can pick it up alongside the older versions. https://github.com/share/sharedb/releases/tag/v3.0.0