### PR TITLE
Add getValues method for fetching array of docs from collection

### DIFF
--- a/src/Model/collections.ts
+++ b/src/Model/collections.ts
@@ -81,7 +81,7 @@ declare module './Model' {
     _getDeepCopy(segments: Segments): any;
 
     /**
-     * Gets array of values of collection at this models path or relative subpath
+     * Gets array of values of collection at this model's path or relative subpath
      *
      * If no values exist at subpath, an empty array is returned
      * @param subpath
@@ -134,7 +134,14 @@ Model.prototype._getDeepCopy = function(segments) {
 };
 
 Model.prototype.getValues = function<S>(subpath?: Path) {
-  return this.filter(subpath, null).get();
+  const value = this.get(subpath);
+  if (value == null) {
+    return [];
+  }
+  if (typeof value !== 'object') {
+    throw new Error(`Found non-object type for getValues('${this.path(subpath)}')`);
+  }
+  return Object.values(value) as ReadonlyDeep<S>[];
 }
 
 Model.prototype.getOrCreateCollection = function(name) {

--- a/src/Model/collections.ts
+++ b/src/Model/collections.ts
@@ -2,6 +2,7 @@ import { Doc } from './Doc';
 import { Model, RootModel } from './Model';
 import { JSONObject } from 'sharedb/lib/sharedb';
 import type { Path, ReadonlyDeep, ShallowCopiedValue, Segments } from '../types';
+
 var LocalDoc = require('./LocalDoc');
 var util = require('../util');
 
@@ -78,6 +79,14 @@ declare module './Model' {
     _get(segments: Segments): any;
     _getCopy(segments: Segments): any;
     _getDeepCopy(segments: Segments): any;
+
+    /**
+     * Gets array of values of collection at this models path or relative subpath
+     *
+     * If no values exist at subpath, an empty array is returned
+     * @param subpath
+     */
+    getValues<S>(subpath?: Path): ReadonlyDeep<S>[];
   }
 }
 
@@ -123,6 +132,10 @@ Model.prototype._getDeepCopy = function(segments) {
   var value = this._get(segments);
   return util.deepCopy(value);
 };
+
+Model.prototype.getValues = function<S>(subpath?: Path) {
+  return this.filter(subpath, null).get();
+}
 
 Model.prototype.getOrCreateCollection = function(name) {
   var collection = this.root.collections[name];

--- a/test/Model/collections.js
+++ b/test/Model/collections.js
@@ -7,12 +7,9 @@ describe('collections', () => {
       const model = new RootModel();
       model.add('_test_docs', {name: 'foo'});
       model.add('_test_docs', {name: 'bar'});
-
       const values = model.getValues('_test_docs');
-
       expect(values).to.be.instanceOf(Array);
       expect(values).to.have.lengthOf(2);
-
       ['foo', 'bar'].forEach((value, index) => {
         expect(values[index]).to.have.property('name', value);
       });
@@ -20,11 +17,17 @@ describe('collections', () => {
 
     it('return empty array when no values at subpath', () => {
       const model = new RootModel();
-
       const values = model.getValues('_test_docs');
-
       expect(values).to.be.instanceOf(Array);
       expect(values).to.have.lengthOf(0);
+    });
+
+    it('throws error if non-object result at path', () => {
+      const model = new RootModel();
+      const id = model.add('_colors', {rgb: 3});
+      expect(
+        () => model.getValues(`_colors.${id}.rgb`),
+      ).to.throw(`Found non-object type for getValues('_colors.${id}.rgb')`);
     });
   });
 });

--- a/test/Model/collections.js
+++ b/test/Model/collections.js
@@ -26,7 +26,7 @@ describe('collections', () => {
       const model = new RootModel();
       const id = model.add('_colors', {rgb: 3});
       expect(
-        () => model.getValues(`_colors.${id}.rgb`),
+        () => model.getValues(`_colors.${id}.rgb`)
       ).to.throw(`Found non-object type for getValues('_colors.${id}.rgb')`);
     });
   });

--- a/test/Model/collections.js
+++ b/test/Model/collections.js
@@ -1,0 +1,30 @@
+const {expect} = require('../util');
+const {RootModel} = require('../../lib');
+
+describe('collections', () => {
+  describe('getValues', () => {
+    it('returns array of values from collection', () => {
+      const model = new RootModel();
+      model.add('_test_docs', {name: 'foo'});
+      model.add('_test_docs', {name: 'bar'});
+
+      const values = model.getValues('_test_docs');
+
+      expect(values).to.be.instanceOf(Array);
+      expect(values).to.have.lengthOf(2);
+
+      ['foo', 'bar'].forEach((value, index) => {
+        expect(values[index]).to.have.property('name', value);
+      });
+    });
+
+    it('return empty array when no values at subpath', () => {
+      const model = new RootModel();
+
+      const values = model.getValues('_test_docs');
+
+      expect(values).to.be.instanceOf(Array);
+      expect(values).to.have.lengthOf(0);
+    });
+  });
+});


### PR DESCRIPTION
Found a pattern of using `filter` with a `null` filter function in production code that was used to get an array of collection values e.g.

```
const users = model.filter('users', null).get() || [];
```

This pattern is unintuitive and highlighted missing functionality to get the collection values.

`getValues` returns an array of docs, and ensures an empty array when no values at path.