### PR TITLE
Add methods getOrDefault and getOrThrow

### DIFF
--- a/src/Model/collections.ts
+++ b/src/Model/collections.ts
@@ -2,6 +2,7 @@ import { Doc } from './Doc';
 import { Model, RootModel } from './Model';
 import { JSONObject } from 'sharedb/lib/sharedb';
 import type { Path, ReadonlyDeep, ShallowCopiedValue, Segments } from '../types';
+
 var LocalDoc = require('./LocalDoc');
 var util = require('../util');
 
@@ -74,6 +75,21 @@ declare module './Model' {
     getDoc(collecitonName: string, id: string): any | undefined;
     getOrCreateCollection(name: string): Collection;
     getOrCreateDoc(collectionName: string, id: string, data: any);
+
+    /**
+     * Get a value that may be undefined but ensure value is returned
+     *
+     * @param subpath
+     * @param defaultValue value to return if no value at subpath
+     */
+    getOrDefault<S>(subpath: Path, defaultValue: S): ReadonlyDeep<S>;
+
+    /**
+     * Get a value and throw error if undefined
+     *
+     * @param subpath
+     */
+    getOrThrow<S>(subpath: Path): ReadonlyDeep<S>;
 
     _get(segments: Segments): any;
     _getCopy(segments: Segments): any;
@@ -150,6 +166,18 @@ Model.prototype._getDocConstructor = function(name: string) {
 Model.prototype.getOrCreateDoc = function(collectionName, id, data) {
   var collection = this.getOrCreateCollection(collectionName);
   return collection.getOrCreateDoc(id, data);
+};
+
+Model.prototype.getOrDefault = function<S>(subpath: Path, defaultValue: S) {
+  return this.get(subpath) ?? defaultValue as ReadonlyDeep<S>;
+};
+
+Model.prototype.getOrThrow = function<S>(subpath?: Path) {
+  const value = this.get(subpath);
+  if (value === undefined) {
+    throw new Error(`No value at path ${subpath}`)
+  }
+  return value;
 };
 
 /**

--- a/test/Model/collections.js
+++ b/test/Model/collections.js
@@ -1,0 +1,36 @@
+const {expect} = require('../util');
+const {RootModel} = require('../../lib');
+
+describe('collections', () => {
+  describe('getOrDefault', () => {
+    it('returns value if defined', () => {
+      const model = new RootModel();
+      model.add('_test_doc', {name: 'foo'});
+      const value = model.getOrDefault('_test_doc', {name: 'bar'});
+      expect(value).not.to.be.undefined;
+    });
+
+    it('returns defuault value if undefined', () => {
+      const model = new RootModel();
+      const defaultValue = {name: 'bar'};
+      const value = model.getOrDefault('_test_doc', defaultValue);
+      expect(value).not.to.be.undefined;
+      expect(value.name).to.equal('bar');
+      expect(value).to.eql(defaultValue);
+    });
+  });
+
+  describe('getOrThrow', () => {
+    it('returns value if defined', () => {
+      const model = new RootModel();
+      model.add('_test_doc', {name: 'foo'});
+      const value = model.getOrThrow('_test_doc', {name: 'bar'});
+      expect(value).not.to.be.undefined;
+    });
+
+    it('thows if value undefined', () => {
+      const model = new RootModel();
+      expect(() => model.getOrThrow('_test_doc', {name: 'bar'})).to.throw(`No value at path _test_doc`);
+    });
+  });
+});


### PR DESCRIPTION
Added methods for common patterns found in production code:

Data we know we should have in app:
```ts
const value = model.get('_page.user')!;
// following code expects value is defined
// will error in less obvious ways as unlikely to handle the cases of undefined
```
using `getOrThrow`
```
const value = model.getOrThrow('_page.user');
// following code will not be reached
// does not need to defensively handle undefined case
```

Data we may or may not have but want to cleaner code
```ts
const files = model.get('files') || [];
```
using `getOrDefault`
```
const files = model.getOrDefault('files', []);
```
