### PR TITLE
Fix breaking change in types introduced by `ValueCallback`

### DIFF
--- a/src/Model/mutators.ts
+++ b/src/Model/mutators.ts
@@ -10,7 +10,7 @@ var RemoveEvent = mutationEvents.RemoveEvent;
 var MoveEvent = mutationEvents.MoveEvent;
 var promisify = util.promisify;
 
-type ValueCallback<T> = ((error: Error | null | undefined, value: T) => void);
+type ValueCallback<T> = ((error: Error | undefined, value: T) => void);
 
 declare module './Model' {
   interface Model<T> {


### PR DESCRIPTION
The introduction of the `ValueCallback` type in #305 inadvertently introduced a breaking change in the types.

It adds an additional constraint that the passed-in callback function must also expect `null` as a possible value for the `err` parameter in addition to `Error` and `undefined` whereas the `ErrorCallback` type does not.

I don't believe `null` is a possible return value for the `err` parameter based on the previous code so suggest removing the `null` from the union type for `err` in `ValueCallback` so that it matches `ErrorCallback`