### PR TITLE
[TS typings] Allow model.ref's to param to be a Query or Filter, to match implementation

### DIFF
--- a/src/Model/ref.ts
+++ b/src/Model/ref.ts
@@ -47,7 +47,7 @@ declare module './Model' {
      *
      * @see https://derbyjs.github.io/derby/models/refs
      */
-    ref<S>(to: PathLike): ChildModel<S>;
+    ref<S>(to: Refable): ChildModel<S>;
     /**
      * Creates a reference at `path` pointing to another path `to`. Like a
      * symlink, any reads/writes on `path` will work as if they were done on
@@ -61,7 +61,7 @@ declare module './Model' {
      *
      * @see https://derbyjs.github.io/derby/models/refs
      */
-    ref<S>(path: PathLike, to: PathLike, options?: RefOptions): ChildModel<S>;
+    ref<S>(path: PathLike, to: Refable, options?: RefOptions): ChildModel<S>;
     _ref<T>(from: Segments, to: Segments, options?: RefOptions): void;
 
     /**


### PR DESCRIPTION
The implementation of `model.ref` allows the `to` param to be a Query or Filter. In those cases, it calls that query or filter object's `ref` method:
https://github.com/derbyjs/racer/blob/d8fbfcd097084385dec87f17aaf46efeb4582626/src/Model/ref.ts#L259-L260

This updates the TypeScript typings for `model.ref` to allow that use-case.