### PR TITLE
Deprecate model fn; fix type for fn args

### DIFF
--- a/src/Model/fn.ts
+++ b/src/Model/fn.ts
@@ -7,7 +7,7 @@ var util = require('../util');
 
 class NamedFns { }
 
-type StartFnParam = string | number | boolean | null | undefined | ReadonlyDeep<unknown>;
+type StartFnParam = unknown;
 
 type ModelFn<Ins extends unknown[], Out> =
   (...inputs: Ins) => Out |
@@ -89,6 +89,10 @@ declare module './Model' {
      *
      * It's not recommended to use this in most cases. Instead, to share reactive functions,
      * have the components import a shared function to pass to `model.start`.
+     *
+     * @deprecated The use of named funcitons is deprecated. With typescript and modern tooling
+     * you get better type information, code navigation, and refactoring support that is lost
+     * when using named functions.
      *
      * @param name name of the function to define
      * @param fn either a reactive function that accepts inputs and returns output, or

--- a/src/Model/fn.ts
+++ b/src/Model/fn.ts
@@ -90,9 +90,8 @@ declare module './Model' {
      * It's not recommended to use this in most cases. Instead, to share reactive functions,
      * have the components import a shared function to pass to `model.start`.
      *
-     * @deprecated The use of named funcitons is deprecated. With typescript and modern tooling
-     * you get better type information, code navigation, and refactoring support that is lost
-     * when using named functions.
+     * @deprecated The use of named functions is deprecated. Instead, to share a reactive function,
+     * you should export it and then require/import it into each file that needs to use it.
      *
      * @param name name of the function to define
      * @param fn either a reactive function that accepts inputs and returns output, or


### PR DESCRIPTION
With typescript and modern tooling, named functions have some drawbacks when compared to using functions directly, so marking as deprecated. 

Changed `StartFnParam` type to just use `undefined` (was found as issue removing named functions in some production code)