### PR TITLE
Fixes for TS type issues introduced in racer@2.2.0 / TS 5.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "typedoc": "^0.25.13",
     "typedoc-plugin-mdn-links": "^3.1.28",
     "typedoc-plugin-missing-exports": "^2.2.0",
-    "typescript": "^5.1.3"
+    "typescript": "~5.5"
   },
   "bugs": {
     "url": "https://github.com/derbyjs/racer/issues"

--- a/package.json
+++ b/package.json
@@ -42,9 +42,9 @@
     "eslint-config-google": "^0.14.0",
     "mocha": "^9.1.3",
     "nyc": "^15.1.0",
-    "typedoc": "^0.25.13",
+    "typedoc": "^0.26.5",
     "typedoc-plugin-mdn-links": "^3.1.28",
-    "typedoc-plugin-missing-exports": "^2.2.0",
+    "typedoc-plugin-missing-exports": "^3.0.0",
     "typescript": "~5.5"
   },
   "bugs": {

--- a/src/Model/index.ts
+++ b/src/Model/index.ts
@@ -1,5 +1,5 @@
-/// <reference path="./bundle.ts" />
-/// <reference path="./connection.server.ts" />
+/// <reference path="./bundle.ts" preserve="true" />
+/// <reference path="./connection.server.ts" preserve="true" />
 
 import { serverRequire } from '../util';
 export { Model, ChildModel, RootModel, type ModelOptions, type UUID, type DefualtType } from './Model';

--- a/src/util.ts
+++ b/src/util.ts
@@ -229,6 +229,8 @@ export function serverUse(module, id: string, options?: unknown) {
   return this.use(plugin, options);
 }
 
+type Plugin<T extends {}, O> = (pluginHost: T, options: O) => void;
+
 /**
  * Use plugin
  * 
@@ -236,9 +238,9 @@ export function serverUse(module, id: string, options?: unknown) {
  * @param options - Optional options passed to plugin
  * @returns 
  */
-export function use(plugin: (arg0: unknown, options?: unknown) => void, options?: unknown) {
+export function use<T extends {}, O>(this: T, plugin: Plugin<T, O>, options?: O) {
   // Don't include a plugin more than once
-  var plugins = this._plugins || (this._plugins = []);
+  var plugins = (this as any)._plugins || ((this as any)._plugins = []);
   if (plugins.indexOf(plugin) === -1) {
     plugins.push(plugin);
     plugin(this, options);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,8 @@
 {
   "compilerOptions": {
     "allowJs": true,
-    "ignoreDeprecations": "5.0",
     "lib":[],
     "module": "CommonJS",
-    "noImplicitUseStrict": true,
     "outDir": "lib",
     "target": "ES5",
     "sourceMap": false,


### PR DESCRIPTION
racer@2.2.0 introduced a handful of TypeScript errors when used with Derby.

## Fix Derby `app.use(plugin, options)` TS error

When registering a Derby app plugin with strict types, racer@2.2.0 introduced errors like this:
```
Argument of type '(app: App, appName: string) => void' is not assignable to parameter of type '(arg0: unknown, options?: unknown) => void'.
  Types of parameters 'app' and 'arg0' are incompatible.
    Type 'unknown' is not assignable to type 'App'.
```

Derby utilizes the plugin `use` function from Racer, which in racer@2.2.0 switched the plugin function from implicit `any`s to explicit `unknown`s.

This changes the `use` function to use inferred generic types, which allows proper verification that the plugin uses the correct `options` and `this` if specified.

## TS 5.5 related updates

Updates to have Racer work properly with TS 5.5:
- The triple-slash reference directives used to load types for server-only model methods are no longer automatically included in the output d.ts files.
    - This was causing TS errors like `Property 'createConnection' does not exist on type 'RootModel'.` in Derby.
    - We need to add `preserve="true"` to tell the compiler to include them.
- Remove `noImplicitUseStrict` compiler flag, since TS 5.5 no longer supports it
    - This means the output JS files with each have a `"use strict";` at the top
- Update typedoc deps for TS 5.5 compatibility

The TypeScript dependency was using `^5.1`, which was automatically picking up new major TypeScript versions. TS doesn't use semver, and each +0.1 is treated as a major version.

This switches to using a `~` dependency so Racer wont pick up major TS releases automatically.