### PR TITLE
Update `model.start()` type for two-way reactive functions

### DIFF
--- a/src/Model/fn.ts
+++ b/src/Model/fn.ts
@@ -9,11 +9,20 @@ class NamedFns { }
 
 type StartFnParam = unknown;
 
+// From type-fest: https://github.com/sindresorhus/type-fest
+type ArrayIndices<Element extends readonly unknown[]> =
+  Exclude<Partial<Element>['length'], Element['length']>;
+
+type TwoWayReactiveFnSetReturnType<Ins extends readonly unknown[]> =
+  Partial<Ins> |
+  Partial<{ [K in Extract<ArrayIndices<Ins>, number>]: Ins[K] }> |
+  null;
+
 type ModelFn<Ins extends unknown[], Out> =
   ((...inputs: Ins) => Out) |
   {
-    get(...inputs: Ins): Out,
-    set(output: Out, ...inputs: Ins): {[key: number] : Ins[number]} | Ins[] | null,
+    get(...inputs: Ins): Out;
+    set(output: Out, ...inputs: Ins): TwoWayReactiveFnSetReturnType<Ins>;
   };
 
 interface ModelStartOptions {
@@ -99,11 +108,7 @@ declare module './Model' {
      */
     fn<Ins extends unknown[], Out>(
       name: string,
-      fn: (...inputs: Ins) => Out |
-        {
-          get(...inputs: Ins): Out;
-          set(output: Out, ...inputs: Ins): void
-        }
+      fn: ModelFn<Ins, Out>
     ): void;
 
     /**

--- a/src/Model/fn.ts
+++ b/src/Model/fn.ts
@@ -10,10 +10,10 @@ class NamedFns { }
 type StartFnParam = unknown;
 
 type ModelFn<Ins extends unknown[], Out> =
-  (...inputs: Ins) => Out |
+  ((...inputs: Ins) => Out) |
   {
-    get(...inputs: Ins): Out,
-    set(output: Out, ...inputs: Ins): void,
+    get(...inputs: Ins): Out;
+    set(output: Out, ...inputs: Ins): {[key: number] : Ins[number]} | Ins[] | null;
   };
 
 interface ModelStartOptions {

--- a/src/Model/fn.ts
+++ b/src/Model/fn.ts
@@ -12,8 +12,8 @@ type StartFnParam = unknown;
 type ModelFn<Ins extends unknown[], Out> =
   ((...inputs: Ins) => Out) |
   {
-    get(...inputs: Ins): Out;
-    set(output: Out, ...inputs: Ins): {[key: number] : Ins[number]} | Ins[] | null;
+    get(...inputs: Ins): Out,
+    set(output: Out, ...inputs: Ins): {[key: number] : Ins[number]} | Ins[] | null,
   };
 
 interface ModelStartOptions {


### PR DESCRIPTION
Update `model.start()` type `ModelFn` to accept an object with `get/set` methods as an alternative to the function, rather than an alternate return type of that function.

`set` type also should allow return values as per the docs:
https://derbyjs.github.io/derby/models/reactive-functions#two-way-reactive-functions